### PR TITLE
Fix total not recalculated after swipe delete

### DIFF
--- a/app/src/main/java/com/d4rk/cartcalculator/app/cart/details/ui/CartViewModel.kt
+++ b/app/src/main/java/com/d4rk/cartcalculator/app/cart/details/ui/CartViewModel.kt
@@ -120,9 +120,12 @@ class CartViewModel(
             deleteCartItemUseCase(param = item).collect { result : DataState<Unit , Errors> ->
                 if (result is DataState.Success) {
                     updateUi {
-                        copy(cartItems = cartItems.filter { it.itemId != item.itemId })
+                        val updatedItems = cartItems.filter { it.itemId != item.itemId }
+                        copy(
+                            cartItems = updatedItems ,
+                            totalPrice = updatedItems.sumOf { it.price.toDouble() * it.quantity }
+                        )
                     }
-                    calculateTotalPrice()
                     postSnackbar(resId = R.string.item_removed_successfully , isError = false)
                     checkForEmptyItems()
                 }


### PR DESCRIPTION
## Summary
- recalc total price when removing items

## Testing
- `./gradlew test --quiet` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846d14b2670832d808cf59114a036be