### PR TITLE
Add translations for search-related strings

### DIFF
--- a/app/src/main/res/values-ar-rEG/strings.xml
+++ b/app/src/main/res/values-ar-rEG/strings.xml
@@ -17,6 +17,17 @@
     <string name="select_currency_icon_description">أيقونة اختيار العملة</string>
 
     <!-- Home screen -->
+    <string name="search">يبحث</string>
+    <string name="search_placeholder_focused">يبحث…</string>
+    <string name="search_placeholder_refine">صقل بحثك ...</string>
+    <string name="search_placeholder_default">ابحث في العربات</string>
+    <string name="content_description_back">خلف</string>
+    <string name="content_description_open_menu">افتح القائمة</string>
+    <string name="content_description_clear_search">بحث واضح</string>
+    <string name="content_description_voice_search">البحث الصوتي</string>
+    <string name="voice_search_prompt">تكلم الآن…</string>
+    <string name="voice_recognition_not_available">التعرف على الصوت غير متوفر</string>
+    <string name="content_description_more_options">المزيد من الخيارات</string>
     <string name="import_shared_cart">استيراد عربية مشتركة</string>
     <string name="default_sort">الترتيب الافتراضي</string>
     <string name="date">الأقدم أولاً</string>

--- a/app/src/main/res/values-bg-rBG/strings.xml
+++ b/app/src/main/res/values-bg-rBG/strings.xml
@@ -16,6 +16,17 @@
     <string name="onboarding_summary_select_currency_placeholder">Изберете предпочитаната от вас валута</string>
     <string name="select_currency_icon_description">Икона за избор на валута</string>
 
+    <string name="search">Търсене</string>
+    <string name="search_placeholder_focused">Търсене ...</string>
+    <string name="search_placeholder_refine">Прецизирайте търсенето си ...</string>
+    <string name="search_placeholder_default">Търсене в колички</string>
+    <string name="content_description_back">Назад</string>
+    <string name="content_description_open_menu">Отворете менюто</string>
+    <string name="content_description_clear_search">Ясно търсене</string>
+    <string name="content_description_voice_search">Гласово търсене</string>
+    <string name="voice_search_prompt">Говорете сега ...</string>
+    <string name="voice_recognition_not_available">Разпознаването на глас не е налично</string>
+    <string name="content_description_more_options">Още опции</string>
     <string name="import_shared_cart">Импортиране на споделена количка</string>
     <string name="default_sort">Подразбиране</string>
     <string name="date">Най-старите първо</string>

--- a/app/src/main/res/values-bn-rBD/strings.xml
+++ b/app/src/main/res/values-bn-rBD/strings.xml
@@ -17,6 +17,17 @@
     <string name="select_currency_icon_description">মুদ্রা নির্বাচনের জন্য আইকন</string>
 
     <!-- Home screen -->
+    <string name="search">অনুসন্ধান</string>
+    <string name="search_placeholder_focused">অনুসন্ধান…</string>
+    <string name="search_placeholder_refine">আপনার অনুসন্ধান পরিমার্জন…</string>
+    <string name="search_placeholder_default">কার্টে অনুসন্ধান করুন</string>
+    <string name="content_description_back">পিছনে</string>
+    <string name="content_description_open_menu">খোলা মেনু</string>
+    <string name="content_description_clear_search">পরিষ্কার অনুসন্ধান</string>
+    <string name="content_description_voice_search">ভয়েস অনুসন্ধান</string>
+    <string name="voice_search_prompt">এখন কথা বলুন…</string>
+    <string name="voice_recognition_not_available">ভয়েস স্বীকৃতি পাওয়া যায় না</string>
+    <string name="content_description_more_options">আরও বিকল্প</string>
     <string name="import_shared_cart">শেয়ার করা কার্ট ইম্পোর্ট করুন</string>
     <string name="default_sort">ডিফল্ট ক্রম</string>
     <string name="date">পুরানো প্রথমে</string>

--- a/app/src/main/res/values-de-rDE/strings.xml
+++ b/app/src/main/res/values-de-rDE/strings.xml
@@ -16,6 +16,17 @@
     <string name="onboarding_summary_select_currency_placeholder">Wähle deine bevorzugte Währung</string>
     <string name="select_currency_icon_description">Symbol für die Währungsauswahl</string>
 
+    <string name="search">Suchen</string>
+    <string name="search_placeholder_focused">Suchen…</string>
+    <string name="search_placeholder_refine">Verfeinern Sie Ihre Suche…</string>
+    <string name="search_placeholder_default">In Karren suchen</string>
+    <string name="content_description_back">Zurück</string>
+    <string name="content_description_open_menu">Öffnen Sie das Menü</string>
+    <string name="content_description_clear_search">Klare Suche</string>
+    <string name="content_description_voice_search">Sprachsuche</string>
+    <string name="voice_search_prompt">Sprich jetzt…</string>
+    <string name="voice_recognition_not_available">Spracherkennung nicht verfügbar</string>
+    <string name="content_description_more_options">Weitere Optionen</string>
     <string name="import_shared_cart">Geteilten Warenkorb importieren</string>
     <string name="default_sort">Standardreihenfolge</string>
     <string name="date">Älteste zuerst</string>

--- a/app/src/main/res/values-es-rGQ/strings.xml
+++ b/app/src/main/res/values-es-rGQ/strings.xml
@@ -16,6 +16,17 @@
     <string name="onboarding_summary_select_currency_placeholder">Elige tu moneda preferida</string>
     <string name="select_currency_icon_description">Icono para seleccionar moneda</string>
 
+    <string name="search">Buscar</string>
+    <string name="search_placeholder_focused">Buscar…</string>
+    <string name="search_placeholder_refine">Refina tu búsqueda ...</string>
+    <string name="search_placeholder_default">Buscar en carros</string>
+    <string name="content_description_back">Atrás</string>
+    <string name="content_description_open_menu">Menú abierto</string>
+    <string name="content_description_clear_search">Búsqueda clara</string>
+    <string name="content_description_voice_search">Búsqueda de voz</string>
+    <string name="voice_search_prompt">Habla ahora…</string>
+    <string name="voice_recognition_not_available">Reconocimiento de voz no disponible</string>
+    <string name="content_description_more_options">Más opciones</string>
     <string name="import_shared_cart">Importar carrito compartido</string>
     <string name="default_sort">Orden predeterminado</string>
     <string name="date">Más antiguos primero</string>

--- a/app/src/main/res/values-es-rMX/strings.xml
+++ b/app/src/main/res/values-es-rMX/strings.xml
@@ -17,6 +17,17 @@
     <string name="select_currency_icon_description">Ícono para seleccionar moneda</string>
 
     <!-- Home screen -->
+    <string name="search">Buscar</string>
+    <string name="search_placeholder_focused">Buscar…</string>
+    <string name="search_placeholder_refine">Refina tu búsqueda ...</string>
+    <string name="search_placeholder_default">Buscar en carros</string>
+    <string name="content_description_back">Atrás</string>
+    <string name="content_description_open_menu">Menú abierto</string>
+    <string name="content_description_clear_search">Búsqueda clara</string>
+    <string name="content_description_voice_search">Búsqueda de voz</string>
+    <string name="voice_search_prompt">Habla ahora…</string>
+    <string name="voice_recognition_not_available">Reconocimiento de voz no disponible</string>
+    <string name="content_description_more_options">Más opciones</string>
     <string name="import_shared_cart">Importar Carrito Compartido</string>
     <string name="default_sort">Orden Predeterminado</string>
     <string name="date">Más Antiguos Primero</string>

--- a/app/src/main/res/values-fil-rPH/strings.xml
+++ b/app/src/main/res/values-fil-rPH/strings.xml
@@ -17,6 +17,17 @@
     <string name="select_currency_icon_description">Icon para sa pagpili ng currency</string>
 
     <!-- Home screen -->
+    <string name="search">Maghanap</string>
+    <string name="search_placeholder_focused">Maghanap…</string>
+    <string name="search_placeholder_refine">Pinuhin ang iyong paghahanap ...</string>
+    <string name="search_placeholder_default">Maghanap sa mga cart</string>
+    <string name="content_description_back">Balik</string>
+    <string name="content_description_open_menu">Buksan ang menu</string>
+    <string name="content_description_clear_search">Malinaw na paghahanap</string>
+    <string name="content_description_voice_search">Paghahanap ng boses</string>
+    <string name="voice_search_prompt">Magsalita ngayon ...</string>
+    <string name="voice_recognition_not_available">Hindi magagamit ang pagkilala sa boses</string>
+    <string name="content_description_more_options">Higit pang mga pagpipilian</string>
     <string name="import_shared_cart">I-import ang Ibinahaging Cart</string>
     <string name="default_sort">Default na Pagkakasunud-sunod</string>
     <string name="date">Pinakaluma Muna</string>

--- a/app/src/main/res/values-fr-rFR/strings.xml
+++ b/app/src/main/res/values-fr-rFR/strings.xml
@@ -16,6 +16,17 @@
     <string name="onboarding_summary_select_currency_placeholder">Choisissez votre devise préférée</string>
     <string name="select_currency_icon_description">Icône de sélection de devise</string>
 
+    <string name="search">Recherche</string>
+    <string name="search_placeholder_focused">Rechercher…</string>
+    <string name="search_placeholder_refine">Affinez votre recherche…</string>
+    <string name="search_placeholder_default">Recherche dans les chariots</string>
+    <string name="content_description_back">Dos</string>
+    <string name="content_description_open_menu">Ouvrir</string>
+    <string name="content_description_clear_search">Recherche claire</string>
+    <string name="content_description_voice_search">Recherche vocale</string>
+    <string name="voice_search_prompt">Parlez maintenant…</string>
+    <string name="voice_recognition_not_available">Reconnaissance vocale non disponible</string>
+    <string name="content_description_more_options">Plus d'options</string>
     <string name="import_shared_cart">Importer le panier partagé</string>
     <string name="default_sort">Ordre par défaut</string>
     <string name="date">Les plus anciens en premier</string>

--- a/app/src/main/res/values-hi-rIN/strings.xml
+++ b/app/src/main/res/values-hi-rIN/strings.xml
@@ -16,6 +16,17 @@
     <string name="onboarding_summary_select_currency_placeholder">अपनी पसंदीदा मुद्रा चुनें</string>
     <string name="select_currency_icon_description">मुद्रा चुनने के लिए आइकन</string>
 
+    <string name="search">खोज</string>
+    <string name="search_placeholder_focused">खोजना…</string>
+    <string name="search_placeholder_refine">अपनी खोज को परिष्कृत करें ...</string>
+    <string name="search_placeholder_default">गाड़ियों में खोजें</string>
+    <string name="content_description_back">पीछे</string>
+    <string name="content_description_open_menu">खुला मेनू</string>
+    <string name="content_description_clear_search">स्पष्ट खोज</string>
+    <string name="content_description_voice_search">आवाज खोज</string>
+    <string name="voice_search_prompt">अब बोलो…</string>
+    <string name="voice_recognition_not_available">आवाज की पहचान उपलब्ध नहीं है</string>
+    <string name="content_description_more_options">अधिक विकल्प</string>
     <string name="import_shared_cart">साझा कार्ट आयात करें</string>
     <string name="default_sort">डिफ़ॉल्ट क्रम</string>
     <string name="date">सबसे पुराने पहले</string>

--- a/app/src/main/res/values-hu-rHU/strings.xml
+++ b/app/src/main/res/values-hu-rHU/strings.xml
@@ -16,6 +16,17 @@
     <string name="onboarding_summary_select_currency_placeholder">Válaszd ki a preferált pénznemet</string>
     <string name="select_currency_icon_description">Ikon pénznem kiválasztásához</string>
 
+    <string name="search">Keresés</string>
+    <string name="search_placeholder_focused">Keresés…</string>
+    <string name="search_placeholder_refine">Finomítsa a keresést ...</string>
+    <string name="search_placeholder_default">Keresés kocsikban</string>
+    <string name="content_description_back">Vissza</string>
+    <string name="content_description_open_menu">Nyissa meg a menüt</string>
+    <string name="content_description_clear_search">Átkutatás</string>
+    <string name="content_description_voice_search">Hangkeresés</string>
+    <string name="voice_search_prompt">Beszélj most ...</string>
+    <string name="voice_recognition_not_available">A hangfelismerés nem áll rendelkezésre</string>
+    <string name="content_description_more_options">További lehetőségek</string>
     <string name="import_shared_cart">Megosztott kosár importálása</string>
     <string name="default_sort">Alapértelmezett sorrend</string>
     <string name="date">Legrégebbi elöl</string>

--- a/app/src/main/res/values-in-rID/strings.xml
+++ b/app/src/main/res/values-in-rID/strings.xml
@@ -16,6 +16,17 @@
     <string name="onboarding_summary_select_currency_placeholder">Pilih mata uang pilihan Anda</string>
     <string name="select_currency_icon_description">Ikon untuk memilih mata uang</string>
 
+    <string name="search">Mencari</string>
+    <string name="search_placeholder_focused">Mencari…</string>
+    <string name="search_placeholder_refine">Perbaiki pencarian Anda…</string>
+    <string name="search_placeholder_default">Cari di gerobak</string>
+    <string name="content_description_back">Kembali</string>
+    <string name="content_description_open_menu">Buka menu</string>
+    <string name="content_description_clear_search">CLEAR Pencarian</string>
+    <string name="content_description_voice_search">Pencarian Suara</string>
+    <string name="voice_search_prompt">Bicara sekarang…</string>
+    <string name="voice_recognition_not_available">Pengenalan suara tidak tersedia</string>
+    <string name="content_description_more_options">Lebih banyak opsi</string>
     <string name="import_shared_cart">Impor Keranjang Bersama</string>
     <string name="default_sort">Urutan Default</string>
     <string name="date">Terlama dulu</string>

--- a/app/src/main/res/values-it-rIT/strings.xml
+++ b/app/src/main/res/values-it-rIT/strings.xml
@@ -16,6 +16,17 @@
     <string name="onboarding_summary_select_currency_placeholder">Scegli la tua valuta preferita</string>
     <string name="select_currency_icon_description">Icona per la selezione della valuta</string>
 
+    <string name="search">Ricerca</string>
+    <string name="search_placeholder_focused">Ricerca…</string>
+    <string name="search_placeholder_refine">Raffina la tua ricerca ...</string>
+    <string name="search_placeholder_default">Cerca nei carrelli</string>
+    <string name="content_description_back">Indietro</string>
+    <string name="content_description_open_menu">Menu aperto</string>
+    <string name="content_description_clear_search">Ricerca chiara</string>
+    <string name="content_description_voice_search">Ricerca vocale</string>
+    <string name="voice_search_prompt">Parla adesso…</string>
+    <string name="voice_recognition_not_available">Riconoscimento vocale non disponibile</string>
+    <string name="content_description_more_options">Più opzioni</string>
     <string name="import_shared_cart">Importa carrello condiviso</string>
     <string name="default_sort">Ordine predefinito</string>
     <string name="date">Più vecchi prima</string>

--- a/app/src/main/res/values-ja-rJP/strings.xml
+++ b/app/src/main/res/values-ja-rJP/strings.xml
@@ -16,6 +16,17 @@
     <string name="onboarding_summary_select_currency_placeholder">ご希望の通貨を選択してください</string>
     <string name="select_currency_icon_description">通貨選択アイコン</string>
 
+    <string name="search">検索</string>
+    <string name="search_placeholder_focused">検索…</string>
+    <string name="search_placeholder_refine">検索を改良してください…</string>
+    <string name="search_placeholder_default">カートで検索します</string>
+    <string name="content_description_back">戻る</string>
+    <string name="content_description_open_menu">メニューを開きます</string>
+    <string name="content_description_clear_search">クリア検索</string>
+    <string name="content_description_voice_search">音声検索</string>
+    <string name="voice_search_prompt">今話せ…</string>
+    <string name="voice_recognition_not_available">音声認識は利用できません</string>
+    <string name="content_description_more_options">その他のオプション</string>
     <string name="import_shared_cart">共有カートをインポート</string>
     <string name="default_sort">デフォルトの順序</string>
     <string name="date">古い順</string>

--- a/app/src/main/res/values-ko-rKR/strings.xml
+++ b/app/src/main/res/values-ko-rKR/strings.xml
@@ -17,6 +17,17 @@
     <string name="select_currency_icon_description">통화 선택 아이콘</string>
 
     <!-- Home screen -->
+    <string name="search">찾다</string>
+    <string name="search_placeholder_focused">찾다…</string>
+    <string name="search_placeholder_refine">검색을 개선하십시오…</string>
+    <string name="search_placeholder_default">카트로 검색하십시오</string>
+    <string name="content_description_back">뒤쪽에</string>
+    <string name="content_description_open_menu">메뉴 열기</string>
+    <string name="content_description_clear_search">명확한 검색</string>
+    <string name="content_description_voice_search">음성 검색</string>
+    <string name="voice_search_prompt">지금 말하세요…</string>
+    <string name="voice_recognition_not_available">음성 인식을 사용할 수 없습니다</string>
+    <string name="content_description_more_options">더 많은 옵션</string>
     <string name="import_shared_cart">공유된 장바구니 가져오기</string>
     <string name="default_sort">기본 정렬</string>
     <string name="date">오래된 순</string>

--- a/app/src/main/res/values-pl-rPL/strings.xml
+++ b/app/src/main/res/values-pl-rPL/strings.xml
@@ -16,6 +16,17 @@
     <string name="onboarding_summary_select_currency_placeholder">Wybierz preferowaną walutę</string>
     <string name="select_currency_icon_description">Ikona wyboru waluty</string>
 
+    <string name="search">Szukaj</string>
+    <string name="search_placeholder_focused">Szukaj…</string>
+    <string name="search_placeholder_refine">Udostępnij swoje wyszukiwanie…</string>
+    <string name="search_placeholder_default">Wyszukaj w wózkach</string>
+    <string name="content_description_back">Z powrotem</string>
+    <string name="content_description_open_menu">Otwarte menu</string>
+    <string name="content_description_clear_search">Wyczyść wyszukiwanie</string>
+    <string name="content_description_voice_search">Wyszukiwanie głosu</string>
+    <string name="voice_search_prompt">Mów teraz…</string>
+    <string name="voice_recognition_not_available">Rozpoznawanie głosu niedostępne</string>
+    <string name="content_description_more_options">Więcej opcji</string>
     <string name="import_shared_cart">Importuj współdzielony koszyk</string>
     <string name="default_sort">Domyślna kolejność</string>
     <string name="date">Najstarsze najpierw</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -16,6 +16,17 @@
     <string name="onboarding_summary_select_currency_placeholder">Escolha sua moeda preferida</string>
     <string name="select_currency_icon_description">Ícone para selecionar moeda</string>
 
+    <string name="search">Procurar</string>
+    <string name="search_placeholder_focused">Procurar…</string>
+    <string name="search_placeholder_refine">Refine sua pesquisa ...</string>
+    <string name="search_placeholder_default">Pesquise em carrinhos</string>
+    <string name="content_description_back">Voltar</string>
+    <string name="content_description_open_menu">Abrir menu</string>
+    <string name="content_description_clear_search">Pesquisa clara</string>
+    <string name="content_description_voice_search">Pesquisa de voz</string>
+    <string name="voice_search_prompt">Fale agora…</string>
+    <string name="voice_recognition_not_available">Reconhecimento de voz não disponível</string>
+    <string name="content_description_more_options">Mais opções</string>
     <string name="import_shared_cart">Importar carrinho compartilhado</string>
     <string name="default_sort">Ordem padrão</string>
     <string name="date">Mais antigos primeiro</string>

--- a/app/src/main/res/values-ro-rRO/strings.xml
+++ b/app/src/main/res/values-ro-rRO/strings.xml
@@ -16,6 +16,17 @@
     <string name="onboarding_summary_select_currency_placeholder">Alegeți moneda preferată</string>
     <string name="select_currency_icon_description">Pictogramă pentru selectarea monedei</string>
 
+    <string name="search">Căutare</string>
+    <string name="search_placeholder_focused">Căutare…</string>
+    <string name="search_placeholder_refine">Rafinați -vă căutarea ...</string>
+    <string name="search_placeholder_default">Căutați în căruțe</string>
+    <string name="content_description_back">Spate</string>
+    <string name="content_description_open_menu">Meniu Deschide</string>
+    <string name="content_description_clear_search">Căutare clară</string>
+    <string name="content_description_voice_search">Căutare vocală</string>
+    <string name="voice_search_prompt">Vorbește acum…</string>
+    <string name="voice_recognition_not_available">Recunoașterea vocală nu este disponibilă</string>
+    <string name="content_description_more_options">Mai multe opțiuni</string>
     <string name="import_shared_cart">Importă coș partajat</string>
     <string name="default_sort">Ordine implicită</string>
     <string name="date">Cele mai vechi primele</string>

--- a/app/src/main/res/values-ru-rRU/strings.xml
+++ b/app/src/main/res/values-ru-rRU/strings.xml
@@ -16,6 +16,17 @@
     <string name="onboarding_summary_select_currency_placeholder">Выберите предпочитаемую валюту</string>
     <string name="select_currency_icon_description">Значок для выбора валюты</string>
 
+    <string name="search">Поиск</string>
+    <string name="search_placeholder_focused">Поиск…</string>
+    <string name="search_placeholder_refine">Уточните свой поиск ...</string>
+    <string name="search_placeholder_default">Поиск в тележках</string>
+    <string name="content_description_back">Назад</string>
+    <string name="content_description_open_menu">Открытое меню</string>
+    <string name="content_description_clear_search">Чистый поиск</string>
+    <string name="content_description_voice_search">Голосовой поиск</string>
+    <string name="voice_search_prompt">Говорите сейчас…</string>
+    <string name="voice_recognition_not_available">Распознавание голоса недоступно</string>
+    <string name="content_description_more_options">Больше вариантов</string>
     <string name="import_shared_cart">Импортировать общий корзину</string>
     <string name="default_sort">Сортировка по умолчанию</string>
     <string name="date">Сначала старые</string>

--- a/app/src/main/res/values-sv-rSE/strings.xml
+++ b/app/src/main/res/values-sv-rSE/strings.xml
@@ -16,6 +16,17 @@
     <string name="onboarding_summary_select_currency_placeholder">Välj din föredragna valuta</string>
     <string name="select_currency_icon_description">Ikon för valutaval</string>
 
+    <string name="search">Söka</string>
+    <string name="search_placeholder_focused">Söka…</string>
+    <string name="search_placeholder_refine">Förfina din sökning ...</string>
+    <string name="search_placeholder_default">Sök i vagnar</string>
+    <string name="content_description_back">Tillbaka</string>
+    <string name="content_description_open_menu">Öppna meny</string>
+    <string name="content_description_clear_search">Tydlig sökning</string>
+    <string name="content_description_voice_search">Röstsökning</string>
+    <string name="voice_search_prompt">Tala nu ...</string>
+    <string name="voice_recognition_not_available">Röstigenkänning inte tillgängligt</string>
+    <string name="content_description_more_options">Fler alternativ</string>
     <string name="import_shared_cart">Importera delad kundvagn</string>
     <string name="default_sort">Standardordning</string>
     <string name="date">Äldst först</string>

--- a/app/src/main/res/values-th-rTH/strings.xml
+++ b/app/src/main/res/values-th-rTH/strings.xml
@@ -16,6 +16,17 @@
     <string name="onboarding_summary_select_currency_placeholder">เลือกสกุลเงินที่คุณต้องการ</string>
     <string name="select_currency_icon_description">ไอคอนสำหรับเลือกสกุลเงิน</string>
 
+    <string name="search">ค้นหา</string>
+    <string name="search_placeholder_focused">ค้นหา…</string>
+    <string name="search_placeholder_refine">ปรับแต่งการค้นหาของคุณ ...</string>
+    <string name="search_placeholder_default">ค้นหาในรถเข็น</string>
+    <string name="content_description_back">กลับ</string>
+    <string name="content_description_open_menu">เปิดเมนู</string>
+    <string name="content_description_clear_search">ล้างการค้นหา</string>
+    <string name="content_description_voice_search">การค้นหาด้วยเสียง</string>
+    <string name="voice_search_prompt">พูดตอนนี้ ...</string>
+    <string name="voice_recognition_not_available">ไม่มีการจดจำเสียง</string>
+    <string name="content_description_more_options">ตัวเลือกเพิ่มเติม</string>
     <string name="import_shared_cart">นำเข้ารถเข็นที่แชร์</string>
     <string name="default_sort">ลำดับเริ่มต้น</string>
     <string name="date">เก่าที่สุดก่อน</string>

--- a/app/src/main/res/values-tr-rTR/strings.xml
+++ b/app/src/main/res/values-tr-rTR/strings.xml
@@ -16,6 +16,17 @@
     <string name="onboarding_summary_select_currency_placeholder">Tercih ettiğiniz para birimini seçin</string>
     <string name="select_currency_icon_description">Para birimi seçimi için simge</string>
 
+    <string name="search">Aramak</string>
+    <string name="search_placeholder_focused">Aramak…</string>
+    <string name="search_placeholder_refine">Aramanızı hassaslaştırın…</string>
+    <string name="search_placeholder_default">Arabalarda arama</string>
+    <string name="content_description_back">Geri</string>
+    <string name="content_description_open_menu">Açık Menü</string>
+    <string name="content_description_clear_search">Arama</string>
+    <string name="content_description_voice_search">Sesli arama</string>
+    <string name="voice_search_prompt">Şimdi konuşun…</string>
+    <string name="voice_recognition_not_available">Ses tanıma mevcut değil</string>
+    <string name="content_description_more_options">Daha Fazla Seçenekler</string>
     <string name="import_shared_cart">Paylaşılan Sepeti İçe Aktar</string>
     <string name="default_sort">Varsayılan Sıralama</string>
     <string name="date">En eskiden yeniye</string>

--- a/app/src/main/res/values-uk-rUA/strings.xml
+++ b/app/src/main/res/values-uk-rUA/strings.xml
@@ -16,6 +16,17 @@
     <string name="onboarding_summary_select_currency_placeholder">Оберіть бажану валюту</string>
     <string name="select_currency_icon_description">Іконка для вибору валюти</string>
 
+    <string name="search">Обшук</string>
+    <string name="search_placeholder_focused">Пошук ...</string>
+    <string name="search_placeholder_refine">Вдосконалити свій пошук ...</string>
+    <string name="search_placeholder_default">Пошук у візках</string>
+    <string name="content_description_back">Спинка</string>
+    <string name="content_description_open_menu">Відкрите меню</string>
+    <string name="content_description_clear_search">Чіткий пошук</string>
+    <string name="content_description_voice_search">Голосовий пошук</string>
+    <string name="voice_search_prompt">Говоріть зараз ...</string>
+    <string name="voice_recognition_not_available">Розпізнавання голосу недоступне</string>
+    <string name="content_description_more_options">Більше варіантів</string>
     <string name="import_shared_cart">Імпортувати спільний кошик</string>
     <string name="default_sort">Сортування за замовчуванням</string>
     <string name="date">Спочатку найстаріші</string>

--- a/app/src/main/res/values-ur-rPK/strings.xml
+++ b/app/src/main/res/values-ur-rPK/strings.xml
@@ -17,6 +17,17 @@
     <string name="select_currency_icon_description">کرنسی منتخب کرنے کے لیے آئیکن</string>
 
     <!-- Home screen -->
+    <string name="search">تلاش</string>
+    <string name="search_placeholder_focused">تلاش…</string>
+    <string name="search_placeholder_refine">اپنی تلاش کو بہتر بنائیں…</string>
+    <string name="search_placeholder_default">گاڑیوں میں تلاش کریں</string>
+    <string name="content_description_back">واپس</string>
+    <string name="content_description_open_menu">مینو کھولیں</string>
+    <string name="content_description_clear_search">واضح تلاش</string>
+    <string name="content_description_voice_search">آواز کی تلاش</string>
+    <string name="voice_search_prompt">اب بولیں…</string>
+    <string name="voice_recognition_not_available">آواز کی پہچان دستیاب نہیں ہے</string>
+    <string name="content_description_more_options">مزید اختیارات</string>
     <string name="import_shared_cart">مشترکہ کارٹ درآمد کریں</string>
     <string name="default_sort">پہلے سے طے شدہ ترتیب</string>
     <string name="date">سب سے پرانا پہلے</string>

--- a/app/src/main/res/values-vi-rVN/strings.xml
+++ b/app/src/main/res/values-vi-rVN/strings.xml
@@ -17,6 +17,17 @@
     <string name="select_currency_icon_description">Biểu tượng chọn đơn vị tiền tệ</string>
 
     <!-- Home screen -->
+    <string name="search">Tìm kiếm</string>
+    <string name="search_placeholder_focused">Tìm kiếm…</string>
+    <string name="search_placeholder_refine">Tinh chỉnh tìm kiếm của bạn…</string>
+    <string name="search_placeholder_default">Tìm kiếm trong xe đẩy</string>
+    <string name="content_description_back">Mặt sau</string>
+    <string name="content_description_open_menu">Mở menu</string>
+    <string name="content_description_clear_search">Tìm kiếm rõ ràng</string>
+    <string name="content_description_voice_search">Tìm kiếm bằng giọng nói</string>
+    <string name="voice_search_prompt">Nói ngay bây giờ…</string>
+    <string name="voice_recognition_not_available">Không có được nhận dạng giọng nói</string>
+    <string name="content_description_more_options">Nhiều lựa chọn hơn</string>
     <string name="import_shared_cart">Nhập giỏ hàng được chia sẻ</string>
     <string name="default_sort">Thứ tự mặc định</string>
     <string name="date">Cũ nhất trước</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -16,6 +16,17 @@
     <string name="onboarding_summary_select_currency_placeholder">選擇您偏好的貨幣</string>
     <string name="select_currency_icon_description">選擇貨幣的圖示</string>
 
+    <string name="search">搜尋</string>
+    <string name="search_placeholder_focused">搜尋…</string>
+    <string name="search_placeholder_refine">完善您的搜索…</string>
+    <string name="search_placeholder_default">在購物車中搜索</string>
+    <string name="content_description_back">後退</string>
+    <string name="content_description_open_menu">開放菜單</string>
+    <string name="content_description_clear_search">清除搜索</string>
+    <string name="content_description_voice_search">語音搜索</string>
+    <string name="voice_search_prompt">現在講…</string>
+    <string name="voice_recognition_not_available">語音識別不可用</string>
+    <string name="content_description_more_options">更多選項</string>
     <string name="import_shared_cart">匯入共享購物車</string>
     <string name="default_sort">預設排序</string>
     <string name="date">最舊的優先</string>


### PR DESCRIPTION
## Summary
- add translations for search UI text across all supported languages

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_685108cc4374832d9fe7c217fe64f676