### PR TITLE
Fix search results not updating on query change

### DIFF
--- a/app/src/main/java/com/d4rk/cartcalculator/app/cart/search/ui/SearchScreen.kt
+++ b/app/src/main/java/com/d4rk/cartcalculator/app/cart/search/ui/SearchScreen.kt
@@ -55,10 +55,8 @@ fun SearchScreen(
     val uiData = screenStateValue.data ?: UiSearchData()
     val context = LocalContext.current
 
-    LaunchedEffect(Unit) {
-        if (!uiData.initialQueryProcessed) {
-            searchViewModel.onEvent(SearchEvent.ProcessInitialQuery(initialQueryEncoded))
-        }
+    LaunchedEffect(initialQueryEncoded) {
+        searchViewModel.onEvent(SearchEvent.ProcessInitialQuery(initialQueryEncoded))
     }
 
     ScreenStateHandler(

--- a/app/src/main/java/com/d4rk/cartcalculator/app/cart/search/ui/SearchViewModel.kt
+++ b/app/src/main/java/com/d4rk/cartcalculator/app/cart/search/ui/SearchViewModel.kt
@@ -56,11 +56,11 @@ class SearchViewModel(
             }
 
             is SearchEvent.ProcessInitialQuery -> {
-                if (screenData?.initialQueryProcessed == false) {
-                    val decodedQuery = runCatching {
-                        event.encodedQuery?.let { Uri.decode(it) } ?: ""
-                    }.getOrDefault("")
+                val decodedQuery = runCatching {
+                    event.encodedQuery?.let { Uri.decode(it) } ?: ""
+                }.getOrDefault("")
 
+                if (decodedQuery != screenData?.currentQuery || screenData?.initialQueryProcessed == false) {
                     screenState.updateData(screenState.value.screenState) {
                         it.copy(currentQuery = decodedQuery, initialQueryProcessed = true)
                     }


### PR DESCRIPTION
## Summary
- ensure search screen processes new query params
- update view model to re-run search when query changes

## Testing
- `sh gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68511c203504832dbafdc541cc74ed31