### PR TITLE
Add sort order translations

### DIFF
--- a/app/src/main/res/values-ar-rEG/strings.xml
+++ b/app/src/main/res/values-ar-rEG/strings.xml
@@ -96,6 +96,10 @@
     <string name="summary_preference_settings_currency">حدد عملتك المفضلة لعرض الأسعار</string>
     <string name="dialog_currency_subtitle">اختار عملتك المفضلة</string>
     <string name="dialog_info_currency">اختيار العملة ده هيستخدم في كل المنصة لعرض أسعار المنتجات، ومعالجة المعاملات، وتقديم تجربة تسوق مخصصة أكتر</string>
+    <string name="sort_order_preference">ترتيب عرض العربات</string>
+    <string name="sort_order_summary">اختار طريقة ترتيب العربات</string>
+    <string name="sort_order_dialog_title">اختار ترتيب الفرز</string>
+    <string name="save">حفظ</string>
     <string name="open_carts_after_creation">فتح العربات بعد إنشائها</string>
     <string name="summary_preference_settings_open_carts_after_creation">فتح العربية تلقائيًا فور إنشائها.</string>
 

--- a/app/src/main/res/values-bg-rBG/strings.xml
+++ b/app/src/main/res/values-bg-rBG/strings.xml
@@ -93,6 +93,10 @@
     <string name="summary_preference_settings_currency">Задайте предпочитаната от вас валута за показване на цените</string>
     <string name="dialog_currency_subtitle">Изберете предпочитаната от вас валута</string>
     <string name="dialog_info_currency">Този избор на валута ще се използва в цялата платформа за показване на цените на продуктите, обработка на транзакции и осигуряване на по-персонализирано пазаруване</string>
+    <string name="sort_order_preference">Ред на сортиране на количките</string>
+    <string name="sort_order_summary">Изберете как да се сортират количките</string>
+    <string name="sort_order_dialog_title">Изберете ред на сортиране</string>
+    <string name="save">Запази</string>
     <string name="open_carts_after_creation">Отворете количките след създаването им</string>
     <string name="summary_preference_settings_open_carts_after_creation">Автоматично отваряне на количка веднага след създаването й.</string>
 

--- a/app/src/main/res/values-bn-rBD/strings.xml
+++ b/app/src/main/res/values-bn-rBD/strings.xml
@@ -96,6 +96,10 @@
     <string name="summary_preference_settings_currency">মূল্য প্রদর্শনের জন্য আপনার পছন্দের মুদ্রা সেট করুন</string>
     <string name="dialog_currency_subtitle">আপনার পছন্দের মুদ্রা নির্বাচন করুন</string>
     <string name="dialog_info_currency">এই মুদ্রা নির্বাচনটি প্ল্যাটফর্ম জুড়ে পণ্যের মূল্য প্রদর্শন, লেনদেন প্রক্রিয়াকরণ এবং আরও ব্যক্তিগতকৃত কেনাকাটার অভিজ্ঞতা প্রদানের জন্য ব্যবহৃত হবে</string>
+    <string name="sort_order_preference">কার্ট সাজানোর ক্রম</string>
+    <string name="sort_order_summary">কার্টগুলো কীভাবে সাজানো হবে বেছে নিন</string>
+    <string name="sort_order_dialog_title">সাজানোর ক্রম নির্বাচন করুন</string>
+    <string name="save">সংরক্ষণ করুন</string>
     <string name="open_carts_after_creation">তৈরির পর কার্ট খুলুন</string>
     <string name="summary_preference_settings_open_carts_after_creation">তৈরি হওয়ার সাথে সাথেই একটি কার্ট স্বয়ংক্রিয়ভাবে খুলুন।</string>
 

--- a/app/src/main/res/values-de-rDE/strings.xml
+++ b/app/src/main/res/values-de-rDE/strings.xml
@@ -93,6 +93,10 @@
     <string name="summary_preference_settings_currency">Legen Sie Ihre bevorzugte Währung für die Anzeige von Preisen fest</string>
     <string name="dialog_currency_subtitle">Wählen Sie Ihre bevorzugte Währung aus</string>
     <string name="dialog_info_currency">Diese Währungsauswahl wird plattformübergreifend verwendet, um Produktpreise anzuzeigen, Transaktionen zu verarbeiten und ein personalisierteres Einkaufserlebnis zu bieten</string>
+    <string name="sort_order_preference">Sortierreihenfolge der Warenkörbe</string>
+    <string name="sort_order_summary">Wählen Sie, wie die Warenkörbe sortiert werden</string>
+    <string name="sort_order_dialog_title">Sortierreihenfolge auswählen</string>
+    <string name="save">Speichern</string>
     <string name="open_carts_after_creation">Warenkörbe nach Erstellung öffnen</string>
     <string name="summary_preference_settings_open_carts_after_creation">Warenkorb nach der Erstellung automatisch öffnen.</string>
 

--- a/app/src/main/res/values-es-rGQ/strings.xml
+++ b/app/src/main/res/values-es-rGQ/strings.xml
@@ -93,6 +93,10 @@
     <string name="summary_preference_settings_currency">Establezca su moneda preferida para mostrar los precios</string>
     <string name="dialog_currency_subtitle">Seleccione su moneda preferida</string>
     <string name="dialog_info_currency">Esta selección de moneda se utilizará en toda la plataforma para mostrar los precios de los productos, procesar transacciones y brindar una experiencia de compra más personalizada</string>
+    <string name="sort_order_preference">Orden de clasificación de carritos</string>
+    <string name="sort_order_summary">Elige cómo se ordenan los carritos</string>
+    <string name="sort_order_dialog_title">Seleccionar orden</string>
+    <string name="save">Guardar</string>
     <string name="open_carts_after_creation">Abrir carritos después de la creación</string>
     <string name="summary_preference_settings_open_carts_after_creation">Abrir automáticamente un carrito inmediatamente después de su creación.</string>
 

--- a/app/src/main/res/values-es-rMX/strings.xml
+++ b/app/src/main/res/values-es-rMX/strings.xml
@@ -96,6 +96,10 @@
     <string name="summary_preference_settings_currency">Establece tu moneda preferida para mostrar los precios</string>
     <string name="dialog_currency_subtitle">Selecciona tu moneda preferida</string>
     <string name="dialog_info_currency">Esta selección de moneda se utilizará en toda la plataforma para mostrar los precios de los productos, procesar transacciones y proporcionar una experiencia de compra más personalizada</string>
+    <string name="sort_order_preference">Orden de clasificación de carritos</string>
+    <string name="sort_order_summary">Elige cómo se ordenan los carritos</string>
+    <string name="sort_order_dialog_title">Seleccionar orden</string>
+    <string name="save">Guardar</string>
     <string name="open_carts_after_creation">Abrir Carritos Después de Crearlos</string>
     <string name="summary_preference_settings_open_carts_after_creation">Abrir automáticamente un carrito inmediatamente después de crearlo.</string>
 

--- a/app/src/main/res/values-fil-rPH/strings.xml
+++ b/app/src/main/res/values-fil-rPH/strings.xml
@@ -96,6 +96,10 @@
     <string name="summary_preference_settings_currency">Itakda ang iyong gustong currency para sa pagpapakita ng mga presyo</string>
     <string name="dialog_currency_subtitle">Piliin ang iyong gustong currency</string>
     <string name="dialog_info_currency">Ang pagpili ng currency na ito ay gagamitin sa buong platform para sa pagpapakita ng mga presyo ng produkto, pagproseso ng mga transaksyon, at pagbibigay ng mas personalized na karanasan sa pamimili</string>
+    <string name="sort_order_preference">Pagkakasunud-sunod ng Cart</string>
+    <string name="sort_order_summary">Piliin kung paano iaayos ang mga cart</string>
+    <string name="sort_order_dialog_title">Piliin ang pagkakasunud-sunod</string>
+    <string name="save">I-save</string>
     <string name="open_carts_after_creation">Buksan ang Mga Cart Pagkatapos Gawin</string>
     <string name="summary_preference_settings_open_carts_after_creation">Awtomatikong buksan ang cart kaagad pagkatapos itong gawin.</string>
 

--- a/app/src/main/res/values-fr-rFR/strings.xml
+++ b/app/src/main/res/values-fr-rFR/strings.xml
@@ -93,6 +93,10 @@
     <string name="summary_preference_settings_currency">Définissez votre devise préférée pour l\'affichage des prix</string>
     <string name="dialog_currency_subtitle">Sélectionnez votre devise préférée</string>
     <string name="dialog_info_currency">Cette sélection de devise sera utilisée sur toute la plateforme pour afficher les prix des produits, traiter les transactions et offrir une expérience d\'achat plus personnalisée</string>
+    <string name="sort_order_preference">Ordre de tri du panier</string>
+    <string name="sort_order_summary">Choisissez comment les paniers sont triés</string>
+    <string name="sort_order_dialog_title">Sélectionnez l'ordre de tri</string>
+    <string name="save">Enregistrer</string>
     <string name="open_carts_after_creation">Ouvrir les paniers après la création</string>
     <string name="summary_preference_settings_open_carts_after_creation">Ouvrir automatiquement un panier immédiatement après sa création.</string>
 

--- a/app/src/main/res/values-hi-rIN/strings.xml
+++ b/app/src/main/res/values-hi-rIN/strings.xml
@@ -93,6 +93,10 @@
     <string name="summary_preference_settings_currency">मूल्य प्रदर्शित करने के लिए अपनी पसंदीदा मुद्रा सेट करें</string>
     <string name="dialog_currency_subtitle">अपनी पसंदीदा मुद्रा चुनें</string>
     <string name="dialog_info_currency">इस मुद्रा चयन का उपयोग पूरे प्लेटफ़ॉर्म पर उत्पाद की कीमतें प्रदर्शित करने, लेन-देन को संसाधित करने और अधिक व्यक्तिगत खरीदारी अनुभव प्रदान करने के लिए किया जाएगा</string>
+    <string name="sort_order_preference">कार्ट छंटाई क्रम</string>
+    <string name="sort_order_summary">निर्धारित करें कि कार्ट कैसे छांटे जाएं</string>
+    <string name="sort_order_dialog_title">छंटाई क्रम चुनें</string>
+    <string name="save">सहेजें</string>
     <string name="open_carts_after_creation">निर्माण के बाद कार्ट खोलें</string>
     <string name="summary_preference_settings_open_carts_after_creation">कार्ट बनते ही उसे अपने आप खोलें।</string>
 

--- a/app/src/main/res/values-hu-rHU/strings.xml
+++ b/app/src/main/res/values-hu-rHU/strings.xml
@@ -93,6 +93,10 @@
     <string name="summary_preference_settings_currency">Állítsa be a preferált pénznemet az árak megjelenítéséhez</string>
     <string name="dialog_currency_subtitle">Válassza ki a kívánt pénznemet</string>
     <string name="dialog_info_currency">Ez a pénznemválasztás a platformon mindenhol használható lesz a termékárak megjelenítéséhez, a tranzakciók feldolgozásához és a személyre szabottabb vásárlási élmény biztosításához</string>
+    <string name="sort_order_preference">Kosarak rendezési sorrendje</string>
+    <string name="sort_order_summary">Válaszd ki, hogyan legyenek rendezve a kosarak</string>
+    <string name="sort_order_dialog_title">Rendezési sorrend kiválasztása</string>
+    <string name="save">Mentés</string>
     <string name="open_carts_after_creation">Kosarak megnyitása a létrehozás után</string>
     <string name="summary_preference_settings_open_carts_after_creation">A kosár automatikus megnyitása közvetlenül a létrehozása után.</string>
 

--- a/app/src/main/res/values-in-rID/strings.xml
+++ b/app/src/main/res/values-in-rID/strings.xml
@@ -93,6 +93,10 @@
     <string name="summary_preference_settings_currency">Tetapkan mata uang pilihan Anda untuk menampilkan harga</string>
     <string name="dialog_currency_subtitle">Pilih mata uang pilihan Anda</string>
     <string name="dialog_info_currency">Pilihan mata uang ini akan digunakan di seluruh platform untuk menampilkan harga produk, memproses transaksi, dan memberikan pengalaman berbelanja yang lebih dipersonalisasi</string>
+    <string name="sort_order_preference">Urutan Penyortiran Keranjang</string>
+    <string name="sort_order_summary">Pilih bagaimana keranjang diurutkan</string>
+    <string name="sort_order_dialog_title">Pilih urutan penyortiran</string>
+    <string name="save">Simpan</string>
     <string name="open_carts_after_creation">Buka Keranjang Setelah Dibuat</string>
     <string name="summary_preference_settings_open_carts_after_creation">Buka keranjang secara otomatis segera setelah dibuat.</string>
 

--- a/app/src/main/res/values-it-rIT/strings.xml
+++ b/app/src/main/res/values-it-rIT/strings.xml
@@ -93,6 +93,10 @@
     <string name="summary_preference_settings_currency">Imposta la tua valuta preferita per la visualizzazione dei prezzi</string>
     <string name="dialog_currency_subtitle">Seleziona la tua valuta preferita</string>
     <string name="dialog_info_currency">Questa selezione di valuta verrà utilizzata su tutta la piattaforma per visualizzare i prezzi dei prodotti, elaborare le transazioni e fornire un\'esperienza di acquisto più personalizzata</string>
+    <string name="sort_order_preference">Ordine di ordinamento dei carrelli</string>
+    <string name="sort_order_summary">Scegli come vengono ordinati i carrelli</string>
+    <string name="sort_order_dialog_title">Seleziona l'ordine di ordinamento</string>
+    <string name="save">Salva</string>
     <string name="open_carts_after_creation">Apri carrelli dopo la creazione</string>
     <string name="summary_preference_settings_open_carts_after_creation">Apri automaticamente un carrello subito dopo la sua creazione.</string>
 

--- a/app/src/main/res/values-ja-rJP/strings.xml
+++ b/app/src/main/res/values-ja-rJP/strings.xml
@@ -93,6 +93,10 @@
     <string name="summary_preference_settings_currency">価格を表示するための希望の通貨を設定します</string>
     <string name="dialog_currency_subtitle">希望の通貨を選択してください</string>
     <string name="dialog_info_currency">この通貨の選択は、プラットフォーム全体で製品価格の表示、取引の処理、およびよりパーソナライズされたショッピング体験の提供に利用されます</string>
+    <string name="sort_order_preference">カートの並び順</string>
+    <string name="sort_order_summary">カートをどの順番で並べるか選択</string>
+    <string name="sort_order_dialog_title">並び順を選択</string>
+    <string name="save">保存</string>
     <string name="open_carts_after_creation">作成後にカートを開く</string>
     <string name="summary_preference_settings_open_carts_after_creation">作成後すぐにカートを自動的に開きます。</string>
 

--- a/app/src/main/res/values-ko-rKR/strings.xml
+++ b/app/src/main/res/values-ko-rKR/strings.xml
@@ -96,6 +96,10 @@
     <string name="summary_preference_settings_currency">가격 표시에 사용할 선호 통화 설정</string>
     <string name="dialog_currency_subtitle">선호하는 통화를 선택하세요</string>
     <string name="dialog_info_currency">이 통화 선택은 플랫폼 전체에서 제품 가격 표시, 거래 처리 및 보다 개인화된 쇼핑 경험 제공에 활용됩니다</string>
+    <string name="sort_order_preference">카트 정렬 순서</string>
+    <string name="sort_order_summary">카트를 어떻게 정렬할지 선택하세요</string>
+    <string name="sort_order_dialog_title">정렬 순서 선택</string>
+    <string name="save">저장</string>
     <string name="open_carts_after_creation">생성 후 장바구니 열기</string>
     <string name="summary_preference_settings_open_carts_after_creation">장바구니 생성 직후 자동으로 엽니다.</string>
 

--- a/app/src/main/res/values-pl-rPL/strings.xml
+++ b/app/src/main/res/values-pl-rPL/strings.xml
@@ -93,6 +93,10 @@
     <string name="summary_preference_settings_currency">Ustaw preferowaną walutę do wyświetlania cen</string>
     <string name="dialog_currency_subtitle">Wybierz preferowaną walutę</string>
     <string name="dialog_info_currency">Ten wybór waluty będzie używany na całej platformie do wyświetlania cen produktów, przetwarzania transakcji i zapewniania bardziej spersonalizowanych zakupów</string>
+    <string name="sort_order_preference">Kolejność sortowania koszyków</string>
+    <string name="sort_order_summary">Wybierz sposób sortowania koszyków</string>
+    <string name="sort_order_dialog_title">Wybierz kolejność sortowania</string>
+    <string name="save">Zapisz</string>
     <string name="open_carts_after_creation">Otwieraj koszyki po utworzeniu</string>
     <string name="summary_preference_settings_open_carts_after_creation">Automatycznie otwieraj koszyk natychmiast po jego utworzeniu.</string>
 

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -93,6 +93,10 @@
     <string name="summary_preference_settings_currency">Defina sua moeda preferida para exibir preços</string>
     <string name="dialog_currency_subtitle">Selecione sua moeda preferida</string>
     <string name="dialog_info_currency">Esta seleção de moeda será utilizada em toda a plataforma para exibir preços de produtos, processar transações e fornecer uma experiência de compra mais personalizada</string>
+    <string name="sort_order_preference">Ordem de classificação dos carrinhos</string>
+    <string name="sort_order_summary">Escolha como os carrinhos são ordenados</string>
+    <string name="sort_order_dialog_title">Selecionar ordem de classificação</string>
+    <string name="save">Salvar</string>
     <string name="open_carts_after_creation">Abrir carrinhos após a criação</string>
     <string name="summary_preference_settings_open_carts_after_creation">Abrir automaticamente um carrinho imediatamente após sua criação.</string>
 

--- a/app/src/main/res/values-ro-rRO/strings.xml
+++ b/app/src/main/res/values-ro-rRO/strings.xml
@@ -93,6 +93,10 @@
     <string name="summary_preference_settings_currency">Setează moneda preferată pentru afișarea prețurilor</string>
     <string name="dialog_currency_subtitle">Selectează moneda preferată</string>
     <string name="dialog_info_currency">Această selecție de monedă va fi utilizată pe platformă pentru afișarea prețurilor produselor, procesarea tranzacțiilor și oferirea unei experiențe de cumpărături mai personalizate</string>
+    <string name="sort_order_preference">Ordinea de sortare a coșurilor</string>
+    <string name="sort_order_summary">Alege cum sunt sortate coșurile</string>
+    <string name="sort_order_dialog_title">Selectează ordinea de sortare</string>
+    <string name="save">Salvează</string>
     <string name="open_carts_after_creation">Deschide coșurile după creare</string>
     <string name="summary_preference_settings_open_carts_after_creation">Deschide automat un coș imediat după ce este creat.</string>
 

--- a/app/src/main/res/values-ru-rRU/strings.xml
+++ b/app/src/main/res/values-ru-rRU/strings.xml
@@ -93,6 +93,10 @@
     <string name="summary_preference_settings_currency">Установите предпочитаемую валюту для отображения цен</string>
     <string name="dialog_currency_subtitle">Выберите предпочитаемую валюту</string>
     <string name="dialog_info_currency">Выбранная валюта будет использоваться на всей платформе для отображения цен на товары, обработки транзакций и обеспечения более персонализированного опыта покупок</string>
+    <string name="sort_order_preference">Порядок сортировки корзин</string>
+    <string name="sort_order_summary">Выберите, как сортируются корзины</string>
+    <string name="sort_order_dialog_title">Выберите порядок сортировки</string>
+    <string name="save">Сохранить</string>
     <string name="open_carts_after_creation">Открывать корзины после создания</string>
     <string name="summary_preference_settings_open_carts_after_creation">Автоматически открывать корзину сразу после ее создания.</string>
 

--- a/app/src/main/res/values-sv-rSE/strings.xml
+++ b/app/src/main/res/values-sv-rSE/strings.xml
@@ -93,6 +93,10 @@
     <string name="summary_preference_settings_currency">Ställ in önskad valuta för att visa priser</string>
     <string name="dialog_currency_subtitle">Välj önskad valuta</string>
     <string name="dialog_info_currency">Detta valutaval kommer att användas över hela plattformen för att visa produktpriser, bearbeta transaktioner och ge en mer personlig shoppingupplevelse</string>
+    <string name="sort_order_preference">Sorteringsordning för kundvagnar</string>
+    <string name="sort_order_summary">Välj hur vagnarna sorteras</string>
+    <string name="sort_order_dialog_title">Välj sorteringsordning</string>
+    <string name="save">Spara</string>
     <string name="open_carts_after_creation">Öppna varukorgar efter skapande</string>
     <string name="summary_preference_settings_open_carts_after_creation">Öppna en varukorg automatiskt direkt efter att den skapats.</string>
 

--- a/app/src/main/res/values-th-rTH/strings.xml
+++ b/app/src/main/res/values-th-rTH/strings.xml
@@ -93,6 +93,10 @@
     <string name="summary_preference_settings_currency">ตั้งค่าสกุลเงินที่คุณต้องการสำหรับการแสดงราคา</string>
     <string name="dialog_currency_subtitle">เลือกสกุลเงินที่คุณต้องการ</string>
     <string name="dialog_info_currency">การเลือกสกุลเงินนี้จะถูกนำไปใช้ทั่วทั้งแพลตฟอร์มสำหรับการแสดงราคาสินค้า การประมวลผลธุรกรรม และมอบประสบการณ์การช็อปปิ้งที่เป็นส่วนตัวยิ่งขึ้น</string>
+    <string name="sort_order_preference">ลำดับการจัดเรียงตะกร้า</string>
+    <string name="sort_order_summary">เลือกวิธีจัดเรียงตะกร้า</string>
+    <string name="sort_order_dialog_title">เลือกลำดับการจัดเรียง</string>
+    <string name="save">บันทึก</string>
     <string name="open_carts_after_creation">เปิดรถเข็นหลังการสร้าง</string>
     <string name="summary_preference_settings_open_carts_after_creation">เปิดรถเข็นโดยอัตโนมัติทันทีหลังจากสร้าง</string>
 

--- a/app/src/main/res/values-tr-rTR/strings.xml
+++ b/app/src/main/res/values-tr-rTR/strings.xml
@@ -93,6 +93,10 @@
     <string name="summary_preference_settings_currency">Fiyatları görüntülemek için tercih ettiğiniz para birimini ayarlayın</string>
     <string name="dialog_currency_subtitle">Tercih ettiğiniz para birimini seçin</string>
     <string name="dialog_info_currency">Bu para birimi seçimi, ürün fiyatlarını görüntülemek, işlemleri gerçekleştirmek ve daha kişiselleştirilmiş bir alışveriş deneyimi sağlamak için platform genelinde kullanılacaktır</string>
+    <string name="sort_order_preference">Sepet Sıralama Düzeni</string>
+    <string name="sort_order_summary">Sepetlerin nasıl sıralanacağını seçin</string>
+    <string name="sort_order_dialog_title">Sıralama düzenini seçin</string>
+    <string name="save">Kaydet</string>
     <string name="open_carts_after_creation">Oluşturulduktan Sonra Sepetleri Aç</string>
     <string name="summary_preference_settings_open_carts_after_creation">Oluşturulduktan hemen sonra bir sepeti otomatik olarak açın.</string>
 

--- a/app/src/main/res/values-uk-rUA/strings.xml
+++ b/app/src/main/res/values-uk-rUA/strings.xml
@@ -93,6 +93,10 @@
     <string name="summary_preference_settings_currency">Встановіть бажану валюту для відображення цін</string>
     <string name="dialog_currency_subtitle">Виберіть бажану валюту</string>
     <string name="dialog_info_currency">Цей вибір валюти буде використовуватися на всій платформі для відображення цін на продукти, обробки транзакцій і забезпечення більш персоналізованого досвіду покупок</string>
+    <string name="sort_order_preference">Порядок сортування кошиків</string>
+    <string name="sort_order_summary">Виберіть, як сортувати кошики</string>
+    <string name="sort_order_dialog_title">Виберіть порядок сортування</string>
+    <string name="save">Зберегти</string>
     <string name="open_carts_after_creation">Відкривати кошики після створення</string>
     <string name="summary_preference_settings_open_carts_after_creation">Автоматично відкривати кошик одразу після його створення.</string>
 

--- a/app/src/main/res/values-ur-rPK/strings.xml
+++ b/app/src/main/res/values-ur-rPK/strings.xml
@@ -96,6 +96,10 @@
     <string name="summary_preference_settings_currency">قیمتیں دکھانے کے لیے اپنی ترجیحی کرنسی سیٹ کریں</string>
     <string name="dialog_currency_subtitle">اپنی ترجیحی کرنسی منتخب کریں</string>
     <string name="dialog_info_currency">یہ کرنسی انتخاب پلیٹ فارم پر مصنوعات کی قیمتیں دکھانے، لین دین پر کارروائی کرنے، اور زیادہ ذاتی نوعیت کا خریداری کا تجربہ فراہم کرنے کے لیے استعمال کیا جائے گا</string>
+    <string name="sort_order_preference">کارٹ ترتیب کا آرڈر</string>
+    <string name="sort_order_summary">کارٹ کس ترتیب سے لگیں گے منتخب کریں</string>
+    <string name="sort_order_dialog_title">ترتیب منتخب کریں</string>
+    <string name="save">محفوظ کریں</string>
     <string name="open_carts_after_creation">بنانے کے بعد کارٹس کھولیں</string>
     <string name="summary_preference_settings_open_carts_after_creation">بنانے کے فوراً بعد کارٹ خود بخود کھولیں۔</string>
 

--- a/app/src/main/res/values-vi-rVN/strings.xml
+++ b/app/src/main/res/values-vi-rVN/strings.xml
@@ -96,6 +96,10 @@
     <string name="summary_preference_settings_currency">Đặt đơn vị tiền tệ ưa thích của bạn để hiển thị giá</string>
     <string name="dialog_currency_subtitle">Chọn đơn vị tiền tệ ưa thích của bạn</string>
     <string name="dialog_info_currency">Lựa chọn đơn vị tiền tệ này sẽ được sử dụng trên toàn nền tảng để hiển thị giá sản phẩm, xử lý giao dịch và cung cấp trải nghiệm mua sắm được cá nhân hóa hơn</string>
+    <string name="sort_order_preference">Thứ tự sắp xếp giỏ hàng</string>
+    <string name="sort_order_summary">Chọn cách sắp xếp các giỏ hàng</string>
+    <string name="sort_order_dialog_title">Chọn thứ tự sắp xếp</string>
+    <string name="save">Lưu</string>
     <string name="open_carts_after_creation">Mở giỏ hàng sau khi tạo</string>
     <string name="summary_preference_settings_open_carts_after_creation">Tự động mở giỏ hàng ngay sau khi được tạo.</string>
 

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -93,6 +93,10 @@
     <string name="summary_preference_settings_currency">設定顯示價格的偏好貨幣</string>
     <string name="dialog_currency_subtitle">選擇您的偏好貨幣</string>
     <string name="dialog_info_currency">此貨幣選擇將在整個平台用於顯示產品價格、處理交易，並提供更個人化的購物體驗</string>
+    <string name="sort_order_preference">購物車排序方式</string>
+    <string name="sort_order_summary">選擇購物車排序方式</string>
+    <string name="sort_order_dialog_title">選擇排序方式</string>
+    <string name="save">儲存</string>
     <string name="open_carts_after_creation">建立後開啟購物車</string>
     <string name="summary_preference_settings_open_carts_after_creation">建立購物車後立即自動開啟。</string>
 


### PR DESCRIPTION
## Summary
- provide translations for sort order prefs in all locales

## Testing
- `./gradlew tasks --no-daemon`
- `./gradlew lint --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_685132013ff0832da864b444f60b197f