### PR TITLE
Add translations for backup strings

### DIFF
--- a/app/src/main/res/values-ar-rEG/strings.xml
+++ b/app/src/main/res/values-ar-rEG/strings.xml
@@ -102,6 +102,31 @@
     <string name="save">حفظ</string>
     <string name="open_carts_after_creation">فتح العربات بعد إنشائها</string>
     <string name="summary_preference_settings_open_carts_after_creation">فتح العربية تلقائيًا فور إنشائها.</string>
+    <string name="backup_carts_title">النسخ الاحتياطي واستعادة بيانات العربة</string>
+    <string name="backup_now">النسخ الاحتياطي الآن</string>
+    <string name="restore_from_backup">استعادة من النسخ الاحتياطي</string>
+    <string name="backup_successful">بدأت عملية النسخ الاحتياطي!</string>
+    <string name="restore_successful">عملية استعادة العملية!</string>
+    <string name="preference_title_cart_backup">النسخ الاحتياطي واستعادة</string>
+    <string name="preference_summary_cart_backup">إدارة النسخ الاحتياطية لك العربة</string>
+    <string name="backup_now_card_title">إنشاء نسخة احتياطية جديدة</string>
+    <string name="backup_now_card_description">تأمين بيانات عربة التسوق عن طريق إنشاء نسخة احتياطية للتخزين المحلي أو السحابة.</string>
+    <string name="restore_card_title">استعادة من النسخ الاحتياطي</string>
+    <string name="restore_card_description">استرجع بيانات عربة التسوق الخاصة بك من ملف نسخ احتياطي تم إنشاؤه مسبقًا.</string>
+    <string name="backup_information_title">معلومات النسخ الاحتياطي</string>
+    <string name="last_backup_date_label">آخر نسخة احتياطية:</string>
+    <string name="never_backed_up">أبداً</string>
+    <string name="auto_backup_title">النسخ الاحتياطية التلقائية</string>
+    <string name="auto_backup_summary">النسخ الاحتياطي تلقائيا بيانات العربة الخاصة بك يوميا.</string>
+    <string name="backup_successful_detail">النسخ الاحتياطي التي تم إنشاؤها بنجاح!
+موقع: %s</string>
+    <string name="backup_cancelled_by_user">نسخة احتياطية من قبل المستخدم.</string>
+    <string name="backup_failed">فشل النسخ الاحتياطي: %s</string>
+    <string name="unknown_error">خطأ غير معروف</string>
+    <string name="unknown_location">موقع غير معروف</string>
+    <string name="restore_successful_detail">تم استعادة البيانات بنجاح من النسخ الاحتياطي.</string>
+    <string name="restore_failed">فشل الاستعادة: %s</string>
+    <string name="restore_cancelled_by_user">استعادة إلغاء المستخدم.</string>
 
     <!-- About screen -->
     <string name="summary_preference_settings_about">اعرف المزيد عن حاسبة المشتريات</string>

--- a/app/src/main/res/values-bg-rBG/strings.xml
+++ b/app/src/main/res/values-bg-rBG/strings.xml
@@ -99,6 +99,31 @@
     <string name="save">Запази</string>
     <string name="open_carts_after_creation">Отворете количките след създаването им</string>
     <string name="summary_preference_settings_open_carts_after_creation">Автоматично отваряне на количка веднага след създаването й.</string>
+    <string name="backup_carts_title">Резервно копие и възстановяване на данните за количката</string>
+    <string name="backup_now">Резервно копие сега</string>
+    <string name="restore_from_backup">Възстановяване от резервно копие</string>
+    <string name="backup_successful">Процесът на архивиране започна!</string>
+    <string name="restore_successful">Иницииран процес на възстановяване!</string>
+    <string name="preference_title_cart_backup">Резервно копие и възстановяване</string>
+    <string name="preference_summary_cart_backup">Управлявайте резервните си колички за колички</string>
+    <string name="backup_now_card_title">Създайте ново резервно копие</string>
+    <string name="backup_now_card_description">Осигурете данните за пазаруването си, като създадете резервно копие на локалното съхранение или облака.</string>
+    <string name="restore_card_title">Възстановяване от резервно копие</string>
+    <string name="restore_card_description">Изтеглете данните за пазаруването си от създаден по -рано резервен файл.</string>
+    <string name="backup_information_title">Информация за архивиране</string>
+    <string name="last_backup_date_label">Последно архивиране:</string>
+    <string name="never_backed_up">Никога</string>
+    <string name="auto_backup_title">Автоматични резервни копия</string>
+    <string name="auto_backup_summary">Автоматично архивирайте данните за количката всеки ден.</string>
+    <string name="backup_successful_detail">Резервно копие създадено успешно!
+Местоположение: %s</string>
+    <string name="backup_cancelled_by_user">Резервно копие от потребителя.</string>
+    <string name="backup_failed">Резервното копие не успя: %s</string>
+    <string name="unknown_error">Неизвестна грешка</string>
+    <string name="unknown_location">Неизвестно местоположение</string>
+    <string name="restore_successful_detail">Данните се възстановяват успешно от архивиране.</string>
+    <string name="restore_failed">Възстановяването не е успешно: %s</string>
+    <string name="restore_cancelled_by_user">Възстановете анулирана от потребителя.</string>
 
     <string name="summary_preference_settings_about">Научете повече за Cart Calculator</string>
 

--- a/app/src/main/res/values-bn-rBD/strings.xml
+++ b/app/src/main/res/values-bn-rBD/strings.xml
@@ -102,6 +102,31 @@
     <string name="save">সংরক্ষণ করুন</string>
     <string name="open_carts_after_creation">তৈরির পর কার্ট খুলুন</string>
     <string name="summary_preference_settings_open_carts_after_creation">তৈরি হওয়ার সাথে সাথেই একটি কার্ট স্বয়ংক্রিয়ভাবে খুলুন।</string>
+    <string name="backup_carts_title">ব্যাকআপ এবং কার্টের ডেটা পুনরুদ্ধার করুন</string>
+    <string name="backup_now">এখন ব্যাকআপ</string>
+    <string name="restore_from_backup">ব্যাকআপ থেকে পুনরুদ্ধার</string>
+    <string name="backup_successful">ব্যাকআপ প্রক্রিয়া শুরু!</string>
+    <string name="restore_successful">পুনরুদ্ধার প্রক্রিয়া শুরু!</string>
+    <string name="preference_title_cart_backup">ব্যাকআপ এবং পুনরুদ্ধার</string>
+    <string name="preference_summary_cart_backup">আপনার কার্ট ব্যাকআপ পরিচালনা করুন</string>
+    <string name="backup_now_card_title">একটি নতুন ব্যাকআপ তৈরি করুন</string>
+    <string name="backup_now_card_description">স্থানীয় স্টোরেজ বা ক্লাউডে ব্যাকআপ তৈরি করে আপনার শপিং কার্টের ডেটা সুরক্ষিত করুন।</string>
+    <string name="restore_card_title">ব্যাকআপ থেকে পুনরুদ্ধার</string>
+    <string name="restore_card_description">পূর্বে তৈরি ব্যাকআপ ফাইল থেকে আপনার শপিং কার্টের ডেটা পুনরুদ্ধার করুন।</string>
+    <string name="backup_information_title">ব্যাকআপ তথ্য</string>
+    <string name="last_backup_date_label">শেষ ব্যাকআপ:</string>
+    <string name="never_backed_up">কখনও না</string>
+    <string name="auto_backup_title">স্বয়ংক্রিয় ব্যাকআপ</string>
+    <string name="auto_backup_summary">আপনার কার্টের ডেটা প্রতিদিন স্বয়ংক্রিয়ভাবে ব্যাক আপ করুন।</string>
+    <string name="backup_successful_detail">ব্যাকআপ সফলভাবে তৈরি!
+অবস্থান: %s</string>
+    <string name="backup_cancelled_by_user">ব্যাকআপ ব্যবহারকারী দ্বারা বাতিল।</string>
+    <string name="backup_failed">ব্যাকআপ ব্যর্থ: %s</string>
+    <string name="unknown_error">অজানা ত্রুটি</string>
+    <string name="unknown_location">অজানা অবস্থান</string>
+    <string name="restore_successful_detail">ব্যাকআপ থেকে সফলভাবে ডেটা পুনরুদ্ধার করা হয়েছে।</string>
+    <string name="restore_failed">পুনরুদ্ধার ব্যর্থ: %s</string>
+    <string name="restore_cancelled_by_user">ব্যবহারকারী দ্বারা বাতিল পুনরুদ্ধার।</string>
 
     <!-- About screen -->
     <string name="summary_preference_settings_about">কার্ট ক্যালকুলেটর সম্পর্কে আরও জানুন</string>

--- a/app/src/main/res/values-de-rDE/strings.xml
+++ b/app/src/main/res/values-de-rDE/strings.xml
@@ -99,6 +99,31 @@
     <string name="save">Speichern</string>
     <string name="open_carts_after_creation">Warenkörbe nach Erstellung öffnen</string>
     <string name="summary_preference_settings_open_carts_after_creation">Warenkorb nach der Erstellung automatisch öffnen.</string>
+    <string name="backup_carts_title">Sicherung und Wiederherstellung von Wagendaten</string>
+    <string name="backup_now">Backup jetzt</string>
+    <string name="restore_from_backup">Vom Backup wiederherstellen</string>
+    <string name="backup_successful">Sicherungsprozess begann!</string>
+    <string name="restore_successful">Wiederherstellungsprozess initiiert!</string>
+    <string name="preference_title_cart_backup">Backup &amp; Wiederherstellung</string>
+    <string name="preference_summary_cart_backup">Verwalten Sie Ihre Karren -Backups</string>
+    <string name="backup_now_card_title">Erstellen Sie eine neue Sicherung</string>
+    <string name="backup_now_card_description">Sichern Sie Ihre Einkaufswagendaten, indem Sie eine Sicherung für den lokalen Speicher oder die Cloud erstellen.</string>
+    <string name="restore_card_title">Vom Backup wiederherstellen</string>
+    <string name="restore_card_description">Rufen Sie Ihre Einkaufswagendaten von einer zuvor erstellten Sicherungsdatei ab.</string>
+    <string name="backup_information_title">Sicherungsinformationen</string>
+    <string name="last_backup_date_label">Letzte Sicherung:</string>
+    <string name="never_backed_up">Niemals</string>
+    <string name="auto_backup_title">Automatische Backups</string>
+    <string name="auto_backup_summary">Sichern Sie Ihre Karren -Daten automatisch täglich.</string>
+    <string name="backup_successful_detail">Backup erfolgreich erstellt!
+Standort: %s</string>
+    <string name="backup_cancelled_by_user">Sicherung durch den Benutzer abgebrochen.</string>
+    <string name="backup_failed">Backup fehlgeschlagen: %s</string>
+    <string name="unknown_error">Unbekannter Fehler</string>
+    <string name="unknown_location">Unbekannter Ort</string>
+    <string name="restore_successful_detail">Daten wurden erfolgreich aus der Backup wiederhergestellt.</string>
+    <string name="restore_failed">Wiederherstellung fehlgeschlagen: %s</string>
+    <string name="restore_cancelled_by_user">Storniert vom Benutzer storniert.</string>
 
     <string name="summary_preference_settings_about">Erfahren Sie mehr über den Warenkorb-Rechner</string>
 

--- a/app/src/main/res/values-es-rGQ/strings.xml
+++ b/app/src/main/res/values-es-rGQ/strings.xml
@@ -99,6 +99,31 @@
     <string name="save">Guardar</string>
     <string name="open_carts_after_creation">Abrir carritos después de la creación</string>
     <string name="summary_preference_settings_open_carts_after_creation">Abrir automáticamente un carrito inmediatamente después de su creación.</string>
+    <string name="backup_carts_title">Copia de seguridad y restauración de datos del carrito</string>
+    <string name="backup_now">Copia de seguridad ahora</string>
+    <string name="restore_from_backup">Restaurar desde la copia de seguridad</string>
+    <string name="backup_successful">¡Comenzando el proceso de copia de seguridad!</string>
+    <string name="restore_successful">¡Iniciado el proceso de restauración!</string>
+    <string name="preference_title_cart_backup">Copia de seguridad y restauración</string>
+    <string name="preference_summary_cart_backup">Administre las copias de seguridad de su carrito</string>
+    <string name="backup_now_card_title">Crea una nueva copia de seguridad</string>
+    <string name="backup_now_card_description">Asegure los datos de su carrito de compras creando una copia de seguridad del almacenamiento local o la nube.</string>
+    <string name="restore_card_title">Restaurar desde la copia de seguridad</string>
+    <string name="restore_card_description">Recupere los datos de su carrito de compras de un archivo de copia de seguridad creado anteriormente.</string>
+    <string name="backup_information_title">Información de respaldo</string>
+    <string name="last_backup_date_label">Última copia de seguridad:</string>
+    <string name="never_backed_up">Nunca</string>
+    <string name="auto_backup_title">Copias de seguridad automáticas</string>
+    <string name="auto_backup_summary">Haga una copia de seguridad automáticamente de los datos de su carrito diariamente.</string>
+    <string name="backup_successful_detail">¡Copia de seguridad creada con éxito!
+Ubicación: %s</string>
+    <string name="backup_cancelled_by_user">Copia de seguridad cancelada por el usuario.</string>
+    <string name="backup_failed">Falló la copia de seguridad: %s</string>
+    <string name="unknown_error">Error desconocido</string>
+    <string name="unknown_location">Ubicación desconocida</string>
+    <string name="restore_successful_detail">Los datos restaurados con éxito desde la copia de seguridad.</string>
+    <string name="restore_failed">Restaurar fallado: %s</string>
+    <string name="restore_cancelled_by_user">Restaurar cancelado por el usuario.</string>
 
     <string name="summary_preference_settings_about">Obtenga más información sobre la Calculadora de Carrito</string>
 

--- a/app/src/main/res/values-es-rMX/strings.xml
+++ b/app/src/main/res/values-es-rMX/strings.xml
@@ -102,6 +102,31 @@
     <string name="save">Guardar</string>
     <string name="open_carts_after_creation">Abrir Carritos Después de Crearlos</string>
     <string name="summary_preference_settings_open_carts_after_creation">Abrir automáticamente un carrito inmediatamente después de crearlo.</string>
+    <string name="backup_carts_title">Copia de seguridad y restauración de datos del carrito</string>
+    <string name="backup_now">Copia de seguridad ahora</string>
+    <string name="restore_from_backup">Restaurar desde la copia de seguridad</string>
+    <string name="backup_successful">¡Comenzando el proceso de copia de seguridad!</string>
+    <string name="restore_successful">¡Iniciado el proceso de restauración!</string>
+    <string name="preference_title_cart_backup">Copia de seguridad y restauración</string>
+    <string name="preference_summary_cart_backup">Administre las copias de seguridad de su carrito</string>
+    <string name="backup_now_card_title">Crea una nueva copia de seguridad</string>
+    <string name="backup_now_card_description">Asegure los datos de su carrito de compras creando una copia de seguridad del almacenamiento local o la nube.</string>
+    <string name="restore_card_title">Restaurar desde la copia de seguridad</string>
+    <string name="restore_card_description">Recupere los datos de su carrito de compras de un archivo de copia de seguridad creado anteriormente.</string>
+    <string name="backup_information_title">Información de respaldo</string>
+    <string name="last_backup_date_label">Última copia de seguridad:</string>
+    <string name="never_backed_up">Nunca</string>
+    <string name="auto_backup_title">Copias de seguridad automáticas</string>
+    <string name="auto_backup_summary">Haga una copia de seguridad automáticamente de los datos de su carrito diariamente.</string>
+    <string name="backup_successful_detail">¡Copia de seguridad creada con éxito!
+Ubicación: %s</string>
+    <string name="backup_cancelled_by_user">Copia de seguridad cancelada por el usuario.</string>
+    <string name="backup_failed">Falló la copia de seguridad: %s</string>
+    <string name="unknown_error">Error desconocido</string>
+    <string name="unknown_location">Ubicación desconocida</string>
+    <string name="restore_successful_detail">Los datos restaurados con éxito desde la copia de seguridad.</string>
+    <string name="restore_failed">Restaurar fallado: %s</string>
+    <string name="restore_cancelled_by_user">Restaurar cancelado por el usuario.</string>
 
     <!-- About screen -->
     <string name="summary_preference_settings_about">Aprende más sobre Cart Calculator</string>

--- a/app/src/main/res/values-fil-rPH/strings.xml
+++ b/app/src/main/res/values-fil-rPH/strings.xml
@@ -102,6 +102,31 @@
     <string name="save">I-save</string>
     <string name="open_carts_after_creation">Buksan ang Mga Cart Pagkatapos Gawin</string>
     <string name="summary_preference_settings_open_carts_after_creation">Awtomatikong buksan ang cart kaagad pagkatapos itong gawin.</string>
+    <string name="backup_carts_title">Backup at ibalik ang data ng cart</string>
+    <string name="backup_now">Backup ngayon</string>
+    <string name="restore_from_backup">Ibalik mula sa backup</string>
+    <string name="backup_successful">Nagsimula ang proseso ng pag -backup!</string>
+    <string name="restore_successful">Ibalik ang proseso ng pagpapanumbalik!</string>
+    <string name="preference_title_cart_backup">Backup at ibalik</string>
+    <string name="preference_summary_cart_backup">Pamahalaan ang iyong mga backup ng cart</string>
+    <string name="backup_now_card_title">Lumikha ng isang bagong backup</string>
+    <string name="backup_now_card_description">I -secure ang iyong data ng shopping cart sa pamamagitan ng paglikha ng isang backup sa lokal na imbakan o ang ulap.</string>
+    <string name="restore_card_title">Ibalik mula sa backup</string>
+    <string name="restore_card_description">Kunin ang iyong data ng shopping cart mula sa isang dating nilikha na backup file.</string>
+    <string name="backup_information_title">Impormasyon sa Pag -backup</string>
+    <string name="last_backup_date_label">Huling backup:</string>
+    <string name="never_backed_up">Hindi kailanman</string>
+    <string name="auto_backup_title">Mga awtomatikong backup</string>
+    <string name="auto_backup_summary">Awtomatikong i -back up ang iyong data sa cart araw -araw.</string>
+    <string name="backup_successful_detail">Matagumpay na nilikha ang backup!
+Lokasyon: %s</string>
+    <string name="backup_cancelled_by_user">Ang backup na kinansela ng gumagamit.</string>
+    <string name="backup_failed">Nabigo ang backup: %s</string>
+    <string name="unknown_error">Hindi kilalang error</string>
+    <string name="unknown_location">Hindi kilalang lokasyon</string>
+    <string name="restore_successful_detail">Matagumpay na naibalik ang data mula sa backup.</string>
+    <string name="restore_failed">Nabigo ang pagpapanumbalik: %s</string>
+    <string name="restore_cancelled_by_user">Ibalik ang kanselado ng gumagamit.</string>
 
     <!-- About screen -->
     <string name="summary_preference_settings_about">Matuto pa tungkol sa Cart Calculator</string>

--- a/app/src/main/res/values-fr-rFR/strings.xml
+++ b/app/src/main/res/values-fr-rFR/strings.xml
@@ -99,6 +99,31 @@
     <string name="save">Enregistrer</string>
     <string name="open_carts_after_creation">Ouvrir les paniers après la création</string>
     <string name="summary_preference_settings_open_carts_after_creation">Ouvrir automatiquement un panier immédiatement après sa création.</string>
+    <string name="backup_carts_title">Données de sauvegarde et de restauration du panier</string>
+    <string name="backup_now">Sauvegarde maintenant</string>
+    <string name="restore_from_backup">Restaurer à partir de la sauvegarde</string>
+    <string name="backup_successful">Le processus de sauvegarde a commencé!</string>
+    <string name="restore_successful">Restaurer le processus initié!</string>
+    <string name="preference_title_cart_backup">Sauvegarde et restauration</string>
+    <string name="preference_summary_cart_backup">Gérez vos sauvegardes de panier</string>
+    <string name="backup_now_card_title">Créer une nouvelle sauvegarde</string>
+    <string name="backup_now_card_description">Sécurisez vos données de panier d'achat en créant une sauvegarde vers le stockage local ou le cloud.</string>
+    <string name="restore_card_title">Restaurer à partir de la sauvegarde</string>
+    <string name="restore_card_description">Récupérez vos données de panier d'achat à partir d'un fichier de sauvegarde précédemment créé.</string>
+    <string name="backup_information_title">Informations de sauvegarde</string>
+    <string name="last_backup_date_label">Dernière sauvegarde:</string>
+    <string name="never_backed_up">Jamais</string>
+    <string name="auto_backup_title">Sauvegardes automatiques</string>
+    <string name="auto_backup_summary">Sauvegardez automatiquement vos données CART quotidiennement.</string>
+    <string name="backup_successful_detail">La sauvegarde a créé avec succès!
+Emplacement: %s</string>
+    <string name="backup_cancelled_by_user">Sauvegarde annulée par l'utilisateur.</string>
+    <string name="backup_failed">Échec de la sauvegarde: %s</string>
+    <string name="unknown_error">Erreur inconnue</string>
+    <string name="unknown_location">Emplacement inconnu</string>
+    <string name="restore_successful_detail">Les données ont été restaurées avec succès à partir de la sauvegarde.</string>
+    <string name="restore_failed">RESTORE Échec: %s</string>
+    <string name="restore_cancelled_by_user">Restauration annulée par l'utilisateur.</string>
 
     <string name="summary_preference_settings_about">En savoir plus sur Cart Calculator</string>
 

--- a/app/src/main/res/values-hi-rIN/strings.xml
+++ b/app/src/main/res/values-hi-rIN/strings.xml
@@ -99,6 +99,31 @@
     <string name="save">सहेजें</string>
     <string name="open_carts_after_creation">निर्माण के बाद कार्ट खोलें</string>
     <string name="summary_preference_settings_open_carts_after_creation">कार्ट बनते ही उसे अपने आप खोलें।</string>
+    <string name="backup_carts_title">बैकअप और कार्ट डेटा को पुनर्स्थापित करें</string>
+    <string name="backup_now">अब समर्थन देना</string>
+    <string name="restore_from_backup">बैकअप से पुनर्स्थापित करें</string>
+    <string name="backup_successful">बैकअप प्रक्रिया शुरू हुई!</string>
+    <string name="restore_successful">पुनर्स्थापना प्रक्रिया शुरू की गई!</string>
+    <string name="preference_title_cart_backup">बैकअप और पुनर्स्थापना</string>
+    <string name="preference_summary_cart_backup">अपने कार्ट बैकअप को प्रबंधित करें</string>
+    <string name="backup_now_card_title">एक नया बैकअप बनाएं</string>
+    <string name="backup_now_card_description">स्थानीय भंडारण या क्लाउड के लिए एक बैकअप बनाकर अपने शॉपिंग कार्ट डेटा को सुरक्षित करें।</string>
+    <string name="restore_card_title">बैकअप से पुनर्स्थापित करें</string>
+    <string name="restore_card_description">पहले से बनाई गई बैकअप फ़ाइल से अपने शॉपिंग कार्ट डेटा को पुनः प्राप्त करें।</string>
+    <string name="backup_information_title">बैकअप सूचना</string>
+    <string name="last_backup_date_label">अंतिम बैकअप:</string>
+    <string name="never_backed_up">कभी नहीं</string>
+    <string name="auto_backup_title">स्वत: बैकअप</string>
+    <string name="auto_backup_summary">अपने कार्ट डेटा को दैनिक रूप से वापस करें।</string>
+    <string name="backup_successful_detail">बैकअप सफलतापूर्वक बनाया!
+जगह: %s</string>
+    <string name="backup_cancelled_by_user">उपयोगकर्ता द्वारा रद्द किया गया बैकअप।</string>
+    <string name="backup_failed">बैकअप विफल: %s</string>
+    <string name="unknown_error">अज्ञात त्रुटि</string>
+    <string name="unknown_location">अज्ञात स्थान</string>
+    <string name="restore_successful_detail">डेटा बैकअप से सफलतापूर्वक बहाल किया गया।</string>
+    <string name="restore_failed">पुनर्स्थापना विफल: %s</string>
+    <string name="restore_cancelled_by_user">उपयोगकर्ता द्वारा रद्द किए गए पुनर्स्थापना।</string>
 
     <string name="summary_preference_settings_about">कार्ट कैलकुलेटर के बारे में अधिक जानें</string>
 

--- a/app/src/main/res/values-hu-rHU/strings.xml
+++ b/app/src/main/res/values-hu-rHU/strings.xml
@@ -99,6 +99,31 @@
     <string name="save">Mentés</string>
     <string name="open_carts_after_creation">Kosarak megnyitása a létrehozás után</string>
     <string name="summary_preference_settings_open_carts_after_creation">A kosár automatikus megnyitása közvetlenül a létrehozása után.</string>
+    <string name="backup_carts_title">Biztonsági másolat és visszaállítja a kosár adatait</string>
+    <string name="backup_now">Biztonsági másolat most</string>
+    <string name="restore_from_backup">Visszaállítás a biztonsági mentésből</string>
+    <string name="backup_successful">A biztonsági mentési folyamat megkezdődött!</string>
+    <string name="restore_successful">Visszaállítja a folyamat kezdeményezett folyamatát!</string>
+    <string name="preference_title_cart_backup">Biztonsági másolat és visszaállítás</string>
+    <string name="preference_summary_cart_backup">Kezelje a kosár biztonsági mentéseit</string>
+    <string name="backup_now_card_title">Hozzon létre egy új biztonsági mentést</string>
+    <string name="backup_now_card_description">Biztosítsa a bevásárlókosár -adatait a helyi tároló vagy a felhő készítésével.</string>
+    <string name="restore_card_title">Visszaállítás a biztonsági mentésből</string>
+    <string name="restore_card_description">Töltse le a bevásárlókosár -adatait egy korábban létrehozott biztonsági mentési fájlból.</string>
+    <string name="backup_information_title">Biztonsági mentési információk</string>
+    <string name="last_backup_date_label">Utolsó biztonsági mentés:</string>
+    <string name="never_backed_up">Soha</string>
+    <string name="auto_backup_title">Automatikus biztonsági mentések</string>
+    <string name="auto_backup_summary">Naponta automatikusan készítsen biztonsági másolatot a kosár adatainak.</string>
+    <string name="backup_successful_detail">A biztonsági mentés sikeresen létrehozta!
+Elhelyezkedés: %s</string>
+    <string name="backup_cancelled_by_user">Biztonsági másolat a felhasználó által törölt.</string>
+    <string name="backup_failed">A biztonsági mentés sikertelen: %s</string>
+    <string name="unknown_error">Ismeretlen hiba</string>
+    <string name="unknown_location">Ismeretlen hely</string>
+    <string name="restore_successful_detail">Az adatok sikeresen helyreállnak a biztonsági mentésből.</string>
+    <string name="restore_failed">A helyreállítás sikertelen: %s</string>
+    <string name="restore_cancelled_by_user">A felhasználó által lemondott visszaállítás.</string>
 
     <string name="summary_preference_settings_about">Tudjon meg többet a Kosár Kalkulátorról</string>
 

--- a/app/src/main/res/values-in-rID/strings.xml
+++ b/app/src/main/res/values-in-rID/strings.xml
@@ -99,6 +99,31 @@
     <string name="save">Simpan</string>
     <string name="open_carts_after_creation">Buka Keranjang Setelah Dibuat</string>
     <string name="summary_preference_settings_open_carts_after_creation">Buka keranjang secara otomatis segera setelah dibuat.</string>
+    <string name="backup_carts_title">Cadangan dan Pulihkan Data Keranjang</string>
+    <string name="backup_now">Cadangan sekarang</string>
+    <string name="restore_from_backup">Kembalikan dari cadangan</string>
+    <string name="backup_successful">Proses cadangan dimulai!</string>
+    <string name="restore_successful">Proses pemulihan dimulai!</string>
+    <string name="preference_title_cart_backup">Cadangan &amp; Pemulihan</string>
+    <string name="preference_summary_cart_backup">Kelola Cadangan Keranjang Anda</string>
+    <string name="backup_now_card_title">Buat cadangan baru</string>
+    <string name="backup_now_card_description">Amankan data keranjang belanja Anda dengan membuat cadangan ke penyimpanan lokal atau cloud.</string>
+    <string name="restore_card_title">Kembalikan dari cadangan</string>
+    <string name="restore_card_description">Ambil data keranjang belanja Anda dari file cadangan yang dibuat sebelumnya.</string>
+    <string name="backup_information_title">Informasi cadangan</string>
+    <string name="last_backup_date_label">Cadangan Terakhir:</string>
+    <string name="never_backed_up">Tidak pernah</string>
+    <string name="auto_backup_title">Cadangan Otomatis</string>
+    <string name="auto_backup_summary">Cadangkan data keranjang Anda secara otomatis setiap hari.</string>
+    <string name="backup_successful_detail">Cadangan dibuat dengan sukses!
+Lokasi: %s</string>
+    <string name="backup_cancelled_by_user">Cadangan dibatalkan oleh pengguna.</string>
+    <string name="backup_failed">Cadangan Gagal: %s</string>
+    <string name="unknown_error">Kesalahan yang tidak diketahui</string>
+    <string name="unknown_location">Lokasi yang tidak diketahui</string>
+    <string name="restore_successful_detail">Data berhasil dipulihkan dari cadangan.</string>
+    <string name="restore_failed">Kembalikan Gagal: %s</string>
+    <string name="restore_cancelled_by_user">Kembalikan dibatalkan oleh pengguna.</string>
 
     <string name="summary_preference_settings_about">Pelajari lebih lanjut tentang Kalkulator Keranjang</string>
 

--- a/app/src/main/res/values-it-rIT/strings.xml
+++ b/app/src/main/res/values-it-rIT/strings.xml
@@ -99,6 +99,31 @@
     <string name="save">Salva</string>
     <string name="open_carts_after_creation">Apri carrelli dopo la creazione</string>
     <string name="summary_preference_settings_open_carts_after_creation">Apri automaticamente un carrello subito dopo la sua creazione.</string>
+    <string name="backup_carts_title">Backup e ripristino dei dati del carrello</string>
+    <string name="backup_now">Backup ora</string>
+    <string name="restore_from_backup">Ripristina dal backup</string>
+    <string name="backup_successful">Processo di backup è iniziato!</string>
+    <string name="restore_successful">Ripristina il processo avviato!</string>
+    <string name="preference_title_cart_backup">Backup e ripristino</string>
+    <string name="preference_summary_cart_backup">Gestisci i tuoi backup del carrello</string>
+    <string name="backup_now_card_title">Crea un nuovo backup</string>
+    <string name="backup_now_card_description">Proteggi i dati del carrello della spesa creando un backup su archiviazione locale o cloud.</string>
+    <string name="restore_card_title">Ripristina dal backup</string>
+    <string name="restore_card_description">Recupera i dati del carrello della spesa da un file di backup precedentemente creato.</string>
+    <string name="backup_information_title">Informazioni di backup</string>
+    <string name="last_backup_date_label">Ultimo backup:</string>
+    <string name="never_backed_up">Mai</string>
+    <string name="auto_backup_title">Backup automatici</string>
+    <string name="auto_backup_summary">Esegui automaticamente il backup dei dati del carrello ogni giorno.</string>
+    <string name="backup_successful_detail">Backup creato con successo!
+Posizione: %s</string>
+    <string name="backup_cancelled_by_user">Backup annullato dall'utente.</string>
+    <string name="backup_failed">Backup non riuscito: %s</string>
+    <string name="unknown_error">Errore sconosciuto</string>
+    <string name="unknown_location">Posizione sconosciuta</string>
+    <string name="restore_successful_detail">Dati ripristinati correttamente dal backup.</string>
+    <string name="restore_failed">Restore fallito: %s</string>
+    <string name="restore_cancelled_by_user">Ripristina cancellato dall'utente.</string>
 
     <string name="summary_preference_settings_about">Ulteriori informazioni su Cart Calculator</string>
 

--- a/app/src/main/res/values-ja-rJP/strings.xml
+++ b/app/src/main/res/values-ja-rJP/strings.xml
@@ -99,6 +99,31 @@
     <string name="save">保存</string>
     <string name="open_carts_after_creation">作成後にカートを開く</string>
     <string name="summary_preference_settings_open_carts_after_creation">作成後すぐにカートを自動的に開きます。</string>
+    <string name="backup_carts_title">カートデータをバックアップして復元します</string>
+    <string name="backup_now">今バックアップ</string>
+    <string name="restore_from_backup">バックアップから復元します</string>
+    <string name="backup_successful">バックアッププロセスが開始されました！</string>
+    <string name="restore_successful">開始されたプロセスの復元！</string>
+    <string name="preference_title_cart_backup">バックアップと復元</string>
+    <string name="preference_summary_cart_backup">カートのバックアップを管理します</string>
+    <string name="backup_now_card_title">新しいバックアップを作成します</string>
+    <string name="backup_now_card_description">ローカルストレージまたはクラウドにバックアップを作成して、ショッピングカートデータを保護します。</string>
+    <string name="restore_card_title">バックアップから復元します</string>
+    <string name="restore_card_description">以前に作成されたバックアップファイルからショッピングカートデータを取得します。</string>
+    <string name="backup_information_title">バックアップ情報</string>
+    <string name="last_backup_date_label">最後のバックアップ：</string>
+    <string name="never_backed_up">一度もない</string>
+    <string name="auto_backup_title">自動バックアップ</string>
+    <string name="auto_backup_summary">毎日カートデータを自動的にバックアップします。</string>
+    <string name="backup_successful_detail">バックアップが正常に作成されました！
+位置： %s</string>
+    <string name="backup_cancelled_by_user">ユーザーによってキャンセルされたバックアップ。</string>
+    <string name="backup_failed">バックアップが失敗しました： %s</string>
+    <string name="unknown_error">不明なエラー</string>
+    <string name="unknown_location">不明な場所</string>
+    <string name="restore_successful_detail">データはバックアップから正常に復元されました。</string>
+    <string name="restore_failed">復元が失敗しました： %s</string>
+    <string name="restore_cancelled_by_user">ユーザーがキャンセルした復元。</string>
 
     <string name="summary_preference_settings_about">カート計算機の詳細</string>
 

--- a/app/src/main/res/values-ko-rKR/strings.xml
+++ b/app/src/main/res/values-ko-rKR/strings.xml
@@ -102,6 +102,31 @@
     <string name="save">저장</string>
     <string name="open_carts_after_creation">생성 후 장바구니 열기</string>
     <string name="summary_preference_settings_open_carts_after_creation">장바구니 생성 직후 자동으로 엽니다.</string>
+    <string name="backup_carts_title">백업 및 카트 데이터를 복원합니다</string>
+    <string name="backup_now">지금 백업</string>
+    <string name="restore_from_backup">백업에서 복원하십시오</string>
+    <string name="backup_successful">백업 프로세스가 시작되었습니다!</string>
+    <string name="restore_successful">프로세스가 시작되었습니다!</string>
+    <string name="preference_title_cart_backup">백업 및 복원</string>
+    <string name="preference_summary_cart_backup">카트 백업을 관리하십시오</string>
+    <string name="backup_now_card_title">새 백업을 만듭니다</string>
+    <string name="backup_now_card_description">로컬 스토리지 또는 클라우드에 대한 백업을 만들어 쇼핑 카트 데이터를 보호하십시오.</string>
+    <string name="restore_card_title">백업에서 복원하십시오</string>
+    <string name="restore_card_description">이전에 생성 된 백업 파일에서 쇼핑 카트 데이터를 검색하십시오.</string>
+    <string name="backup_information_title">백업 정보</string>
+    <string name="last_backup_date_label">마지막 백업 :</string>
+    <string name="never_backed_up">절대</string>
+    <string name="auto_backup_title">자동 백업</string>
+    <string name="auto_backup_summary">매일 카트 데이터를 자동으로 백업하십시오.</string>
+    <string name="backup_successful_detail">백업이 성공적으로 만들어졌습니다!
+위치: %s</string>
+    <string name="backup_cancelled_by_user">백업은 사용자가 취소했습니다.</string>
+    <string name="backup_failed">백업 실패 : %s</string>
+    <string name="unknown_error">알 수없는 오류</string>
+    <string name="unknown_location">알 수없는 위치</string>
+    <string name="restore_successful_detail">백업에서 데이터가 성공적으로 복원되었습니다.</string>
+    <string name="restore_failed">복원 실패 : %s</string>
+    <string name="restore_cancelled_by_user">사용자가 취소 한 복원.</string>
 
     <!-- About screen -->
     <string name="summary_preference_settings_about">카트 계산기에 대해 자세히 알아보기</string>

--- a/app/src/main/res/values-pl-rPL/strings.xml
+++ b/app/src/main/res/values-pl-rPL/strings.xml
@@ -99,6 +99,31 @@
     <string name="save">Zapisz</string>
     <string name="open_carts_after_creation">Otwieraj koszyki po utworzeniu</string>
     <string name="summary_preference_settings_open_carts_after_creation">Automatycznie otwieraj koszyk natychmiast po jego utworzeniu.</string>
+    <string name="backup_carts_title">Tworzenie kopii zapasowych i przywracania danych wózka</string>
+    <string name="backup_now">Kopia zapasowa teraz</string>
+    <string name="restore_from_backup">Przywróć z kopii zapasowej</string>
+    <string name="backup_successful">Rozpoczął się proces tworzenia kopii zapasowych!</string>
+    <string name="restore_successful">Zainicjowany proces przywrócenia!</string>
+    <string name="preference_title_cart_backup">Kopie zapasowe i przywracanie</string>
+    <string name="preference_summary_cart_backup">Zarządzaj kopii zapasowych wózków</string>
+    <string name="backup_now_card_title">Utwórz nową kopię zapasową</string>
+    <string name="backup_now_card_description">Zabezpiecz dane koszyka na zakupy, tworząc kopię zapasową do przechowywania lokalnego lub chmury.</string>
+    <string name="restore_card_title">Przywróć z kopii zapasowej</string>
+    <string name="restore_card_description">Odzyskaj dane w koszyku z wcześniej utworzonego pliku kopii zapasowej.</string>
+    <string name="backup_information_title">Informacje o tworzeniu kopii zapasowych</string>
+    <string name="last_backup_date_label">Ostatnia kopia zapasowa:</string>
+    <string name="never_backed_up">Nigdy</string>
+    <string name="auto_backup_title">Automatyczne kopie zapasowe</string>
+    <string name="auto_backup_summary">Codziennie automatycznie tworz kopie zapasowe danych wózka.</string>
+    <string name="backup_successful_detail">Kopia zapasowa utworzona pomyślnie!
+Lokalizacja: %s</string>
+    <string name="backup_cancelled_by_user">Kopia zapasowa anulowana przez użytkownika.</string>
+    <string name="backup_failed">Kopia zapasowa nie powiodła się: %s</string>
+    <string name="unknown_error">Nieznany błąd</string>
+    <string name="unknown_location">Nieznana lokalizacja</string>
+    <string name="restore_successful_detail">Dane zostały pomyślnie przywrócone po tworzeniu kopii zapasowej.</string>
+    <string name="restore_failed">Przywróć nieudane: %s</string>
+    <string name="restore_cancelled_by_user">Przywróć anulowane przez użytkownika.</string>
 
     <string name="summary_preference_settings_about">Dowiedz się więcej o Kalkulatorze Koszyka</string>
 

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -99,6 +99,31 @@
     <string name="save">Salvar</string>
     <string name="open_carts_after_creation">Abrir carrinhos após a criação</string>
     <string name="summary_preference_settings_open_carts_after_creation">Abrir automaticamente um carrinho imediatamente após sua criação.</string>
+    <string name="backup_carts_title">Backup e restauração de dados do carrinho</string>
+    <string name="backup_now">Backup agora</string>
+    <string name="restore_from_backup">Restaurar do backup</string>
+    <string name="backup_successful">O processo de backup começou!</string>
+    <string name="restore_successful">Processo de restauração iniciada!</string>
+    <string name="preference_title_cart_backup">Backup e restauração</string>
+    <string name="preference_summary_cart_backup">Gerencie seus backups de carrinho</string>
+    <string name="backup_now_card_title">Crie um novo backup</string>
+    <string name="backup_now_card_description">Prenda seus dados do carrinho de compras, criando um backup para o armazenamento local ou a nuvem.</string>
+    <string name="restore_card_title">Restaurar do backup</string>
+    <string name="restore_card_description">Recupere seus dados do carrinho de compras de um arquivo de backup criado anteriormente.</string>
+    <string name="backup_information_title">Informações de backup</string>
+    <string name="last_backup_date_label">Último backup:</string>
+    <string name="never_backed_up">Nunca</string>
+    <string name="auto_backup_title">Backups automáticos</string>
+    <string name="auto_backup_summary">Backup automaticamente seus dados do carrinho diariamente.</string>
+    <string name="backup_successful_detail">Backup criado com sucesso!
+Localização: %s</string>
+    <string name="backup_cancelled_by_user">Backup cancelado pelo usuário.</string>
+    <string name="backup_failed">Backup falhou: %s</string>
+    <string name="unknown_error">Erro desconhecido</string>
+    <string name="unknown_location">Localização desconhecida</string>
+    <string name="restore_successful_detail">Dados restaurados com sucesso do backup.</string>
+    <string name="restore_failed">A restauração falhou: %s</string>
+    <string name="restore_cancelled_by_user">Restauração cancelada pelo usuário.</string>
 
     <string name="summary_preference_settings_about">Saiba mais sobre o Cart Calculator</string>
 

--- a/app/src/main/res/values-ro-rRO/strings.xml
+++ b/app/src/main/res/values-ro-rRO/strings.xml
@@ -99,6 +99,31 @@
     <string name="save">Salvează</string>
     <string name="open_carts_after_creation">Deschide coșurile după creare</string>
     <string name="summary_preference_settings_open_carts_after_creation">Deschide automat un coș imediat după ce este creat.</string>
+    <string name="backup_carts_title">Backup și restaurarea datelor coșului</string>
+    <string name="backup_now">Backup acum</string>
+    <string name="restore_from_backup">Restaurați din backup</string>
+    <string name="backup_successful">Procesul de rezervă a început!</string>
+    <string name="restore_successful">Restaurarea procesului inițiat!</string>
+    <string name="preference_title_cart_backup">Backup și restaurare</string>
+    <string name="preference_summary_cart_backup">Gestionați -vă copiile de rezervă pentru coșuri</string>
+    <string name="backup_now_card_title">Creați o nouă copie de rezervă</string>
+    <string name="backup_now_card_description">Asigurați -vă datele coșului de cumpărături creând o copie de rezervă la stocarea locală sau în cloud.</string>
+    <string name="restore_card_title">Restaurați din backup</string>
+    <string name="restore_card_description">Recuperați datele coșului de cumpărături dintr -un fișier de rezervă creat anterior.</string>
+    <string name="backup_information_title">Informații de rezervă</string>
+    <string name="last_backup_date_label">Ultima copie de rezervă:</string>
+    <string name="never_backed_up">Nu</string>
+    <string name="auto_backup_title">Backup -uri automate</string>
+    <string name="auto_backup_summary">Copiați automat pe datele de coș zilnic.</string>
+    <string name="backup_successful_detail">Backup creat cu succes!
+Locaţie: %s</string>
+    <string name="backup_cancelled_by_user">Backup anulat de utilizator.</string>
+    <string name="backup_failed">Backup a eșuat: %s</string>
+    <string name="unknown_error">Eroare necunoscută</string>
+    <string name="unknown_location">Locație necunoscută</string>
+    <string name="restore_successful_detail">Datele restabilite cu succes din backup.</string>
+    <string name="restore_failed">Restaurarea a eșuat: %s</string>
+    <string name="restore_cancelled_by_user">Restaurați anulat de către utilizator.</string>
 
     <string name="summary_preference_settings_about">Află mai multe despre Cart Calculator</string>
 

--- a/app/src/main/res/values-ru-rRU/strings.xml
+++ b/app/src/main/res/values-ru-rRU/strings.xml
@@ -99,6 +99,31 @@
     <string name="save">Сохранить</string>
     <string name="open_carts_after_creation">Открывать корзины после создания</string>
     <string name="summary_preference_settings_open_carts_after_creation">Автоматически открывать корзину сразу после ее создания.</string>
+    <string name="backup_carts_title">Резервное копирование и восстановление данных корзины</string>
+    <string name="backup_now">Резервное копирование сейчас</string>
+    <string name="restore_from_backup">Восстановите из резервного копирования</string>
+    <string name="backup_successful">Начался процесс резервного копирования!</string>
+    <string name="restore_successful">Восстановить процесс инициирован!</string>
+    <string name="preference_title_cart_backup">Резервное копирование и восстановление</string>
+    <string name="preference_summary_cart_backup">Управляйте своими резервными копиями корзины</string>
+    <string name="backup_now_card_title">Создать новую резервную копию</string>
+    <string name="backup_now_card_description">Защитите данные корзины покупок, создав резервное копирование на локальное хранилище или облако.</string>
+    <string name="restore_card_title">Восстановите из резервного копирования</string>
+    <string name="restore_card_description">Получите данные корзины покупок из ранее созданного файла резервного копирования.</string>
+    <string name="backup_information_title">Резервная информация</string>
+    <string name="last_backup_date_label">Последняя резервная копия:</string>
+    <string name="never_backed_up">Никогда</string>
+    <string name="auto_backup_title">Автоматические резервные копии</string>
+    <string name="auto_backup_summary">Автоматическое резервное копирование данных вашей корзины ежедневно.</string>
+    <string name="backup_successful_detail">Резервная копия создана успешно!
+Расположение: %s</string>
+    <string name="backup_cancelled_by_user">Резервное копирование отменено пользователем.</string>
+    <string name="backup_failed">Резервная копия не удалась: %s</string>
+    <string name="unknown_error">Неизвестная ошибка</string>
+    <string name="unknown_location">Неизвестное место</string>
+    <string name="restore_successful_detail">Данные успешно восстановлены из резервного копирования.</string>
+    <string name="restore_failed">Восстановление не удалось: %s</string>
+    <string name="restore_cancelled_by_user">Восстановить отменен пользователем.</string>
 
     <string name="summary_preference_settings_about">Подробнее о Калькуляторе корзины</string>
 

--- a/app/src/main/res/values-sv-rSE/strings.xml
+++ b/app/src/main/res/values-sv-rSE/strings.xml
@@ -99,6 +99,31 @@
     <string name="save">Spara</string>
     <string name="open_carts_after_creation">Öppna varukorgar efter skapande</string>
     <string name="summary_preference_settings_open_carts_after_creation">Öppna en varukorg automatiskt direkt efter att den skapats.</string>
+    <string name="backup_carts_title">Säkerhetskopiera och återställa vagnsdata</string>
+    <string name="backup_now">Säkerhetskopiering nu</string>
+    <string name="restore_from_backup">Återställ från backup</string>
+    <string name="backup_successful">Säkerhetskopieringsprocess startade!</string>
+    <string name="restore_successful">Återställ processen initierad!</string>
+    <string name="preference_title_cart_backup">Säkerhetskopiering och återställning</string>
+    <string name="preference_summary_cart_backup">Hantera dina säkerhetskopior av kundvagn</string>
+    <string name="backup_now_card_title">Skapa en ny säkerhetskopia</string>
+    <string name="backup_now_card_description">Säkra dina kundvagnsdata genom att skapa en säkerhetskopia till lokal lagring eller molnet.</string>
+    <string name="restore_card_title">Återställ från backup</string>
+    <string name="restore_card_description">Hämta dina kundvagnsdata från en tidigare skapad säkerhetskopieringsfil.</string>
+    <string name="backup_information_title">Backupinformation</string>
+    <string name="last_backup_date_label">Senaste säkerhetskopiering:</string>
+    <string name="never_backed_up">Aldrig</string>
+    <string name="auto_backup_title">Automatiska säkerhetskopior</string>
+    <string name="auto_backup_summary">Säkerhetskopiera automatiskt din vagnsdata dagligen.</string>
+    <string name="backup_successful_detail">Säkerhetskopiering skapades framgångsrikt!
+Plats: %s</string>
+    <string name="backup_cancelled_by_user">Säkerhetskopiering avbröts av användaren.</string>
+    <string name="backup_failed">Säkerhetskopiering misslyckades: %s</string>
+    <string name="unknown_error">Okänt fel</string>
+    <string name="unknown_location">Okänd plats</string>
+    <string name="restore_successful_detail">Data återställdes framgångsrikt från säkerhetskopiering.</string>
+    <string name="restore_failed">Återställ misslyckades: %s</string>
+    <string name="restore_cancelled_by_user">Återställ avbruten av användaren.</string>
 
     <string name="summary_preference_settings_about">Läs mer om Varukorgsberäknaren</string>
 

--- a/app/src/main/res/values-th-rTH/strings.xml
+++ b/app/src/main/res/values-th-rTH/strings.xml
@@ -99,6 +99,31 @@
     <string name="save">บันทึก</string>
     <string name="open_carts_after_creation">เปิดรถเข็นหลังการสร้าง</string>
     <string name="summary_preference_settings_open_carts_after_creation">เปิดรถเข็นโดยอัตโนมัติทันทีหลังจากสร้าง</string>
+    <string name="backup_carts_title">การสำรองข้อมูลและกู้คืนข้อมูลรถเข็น</string>
+    <string name="backup_now">สำรองข้อมูลตอนนี้</string>
+    <string name="restore_from_backup">กู้คืนจากการสำรองข้อมูล</string>
+    <string name="backup_successful">กระบวนการสำรองเริ่มต้น!</string>
+    <string name="restore_successful">กู้คืนกระบวนการเริ่มต้น!</string>
+    <string name="preference_title_cart_backup">สำรองและกู้คืน</string>
+    <string name="preference_summary_cart_backup">จัดการการสำรองข้อมูลรถเข็นของคุณ</string>
+    <string name="backup_now_card_title">สร้างการสำรองข้อมูลใหม่</string>
+    <string name="backup_now_card_description">รักษาความปลอดภัยข้อมูลตะกร้าสินค้าของคุณโดยการสร้างการสำรองข้อมูลไปยังที่เก็บข้อมูลท้องถิ่นหรือคลาวด์</string>
+    <string name="restore_card_title">กู้คืนจากการสำรองข้อมูล</string>
+    <string name="restore_card_description">ดึงข้อมูลตะกร้าสินค้าของคุณจากไฟล์สำรองที่สร้างขึ้นก่อนหน้านี้</string>
+    <string name="backup_information_title">ข้อมูลสำรอง</string>
+    <string name="last_backup_date_label">การสำรองข้อมูลครั้งสุดท้าย:</string>
+    <string name="never_backed_up">ไม่เคย</string>
+    <string name="auto_backup_title">การสำรองข้อมูลอัตโนมัติ</string>
+    <string name="auto_backup_summary">สำรองข้อมูลรถเข็นของคุณโดยอัตโนมัติทุกวัน</string>
+    <string name="backup_successful_detail">การสำรองข้อมูลสร้างสำเร็จ!
+ที่ตั้ง: %s</string>
+    <string name="backup_cancelled_by_user">การสำรองข้อมูลยกเลิกโดยผู้ใช้</string>
+    <string name="backup_failed">การสำรองข้อมูลล้มเหลว: %s</string>
+    <string name="unknown_error">ข้อผิดพลาดที่ไม่รู้จัก</string>
+    <string name="unknown_location">ตำแหน่งที่ไม่รู้จัก</string>
+    <string name="restore_successful_detail">ข้อมูลที่กู้คืนได้สำเร็จจากการสำรองข้อมูล</string>
+    <string name="restore_failed">กู้คืนล้มเหลว: %s</string>
+    <string name="restore_cancelled_by_user">กู้คืนโดยผู้ใช้</string>
 
     <string name="summary_preference_settings_about">เรียนรู้เพิ่มเติมเกี่ยวกับเครื่องคิดเลขในรถเข็น</string>
 

--- a/app/src/main/res/values-tr-rTR/strings.xml
+++ b/app/src/main/res/values-tr-rTR/strings.xml
@@ -99,6 +99,31 @@
     <string name="save">Kaydet</string>
     <string name="open_carts_after_creation">Oluşturulduktan Sonra Sepetleri Aç</string>
     <string name="summary_preference_settings_open_carts_after_creation">Oluşturulduktan hemen sonra bir sepeti otomatik olarak açın.</string>
+    <string name="backup_carts_title">Sepet verilerini yedekleme ve geri yükleme</string>
+    <string name="backup_now">Şimdi yedekleme</string>
+    <string name="restore_from_backup">Yedeklemeden geri yükleme</string>
+    <string name="backup_successful">Yedekleme işlemi başladı!</string>
+    <string name="restore_successful">Geri yükleme işlemi başlatıldı!</string>
+    <string name="preference_title_cart_backup">Yedekleme ve Geri Yükle</string>
+    <string name="preference_summary_cart_backup">Sepet yedeklemelerinizi yönetin</string>
+    <string name="backup_now_card_title">Yeni Bir Yedekleme Oluşturun</string>
+    <string name="backup_now_card_description">Yerel depolama veya buluta bir yedek oluşturarak alışveriş sepeti verilerinizi koruyun.</string>
+    <string name="restore_card_title">Yedeklemeden geri yükleme</string>
+    <string name="restore_card_description">Alışveriş sepeti verilerinizi daha önce oluşturulan bir yedekleme dosyasından alın.</string>
+    <string name="backup_information_title">Yedek Bilgiler</string>
+    <string name="last_backup_date_label">Son yedekleme:</string>
+    <string name="never_backed_up">Asla</string>
+    <string name="auto_backup_title">Otomatik Yedeklemeler</string>
+    <string name="auto_backup_summary">Sepet verilerinizi günlük olarak otomatik olarak yedekleyin.</string>
+    <string name="backup_successful_detail">Yedekleme başarıyla yaratıldı!
+Konum: %s</string>
+    <string name="backup_cancelled_by_user">Yedekleme kullanıcı tarafından iptal edildi.</string>
+    <string name="backup_failed">Yedekleme başarısız oldu: %s</string>
+    <string name="unknown_error">Bilinmeyen hata</string>
+    <string name="unknown_location">Bilinmeyen Konum</string>
+    <string name="restore_successful_detail">Veriler yedeklemeden başarıyla geri yüklendi.</string>
+    <string name="restore_failed">Geri yükleme başarısız: %s</string>
+    <string name="restore_cancelled_by_user">Kullanıcı tarafından iptal edildi.</string>
 
     <string name="summary_preference_settings_about">Sepet Hesaplayıcı hakkında daha fazla bilgi edinin</string>
 

--- a/app/src/main/res/values-uk-rUA/strings.xml
+++ b/app/src/main/res/values-uk-rUA/strings.xml
@@ -99,6 +99,31 @@
     <string name="save">Зберегти</string>
     <string name="open_carts_after_creation">Відкривати кошики після створення</string>
     <string name="summary_preference_settings_open_carts_after_creation">Автоматично відкривати кошик одразу після його створення.</string>
+    <string name="backup_carts_title">Резервне копіювання та відновлення даних кошика</string>
+    <string name="backup_now">Резервне копіювання зараз</string>
+    <string name="restore_from_backup">Відновити з резервного копіювання</string>
+    <string name="backup_successful">Процес резервного копіювання розпочався!</string>
+    <string name="restore_successful">Ініційований процес відновлення!</string>
+    <string name="preference_title_cart_backup">Резервне копіювання та відновлення</string>
+    <string name="preference_summary_cart_backup">Керуйте резервними копіями візка</string>
+    <string name="backup_now_card_title">Створіть нову резервну копію</string>
+    <string name="backup_now_card_description">Забезпечте дані кошика, створивши резервну копію для місцевого зберігання або хмари.</string>
+    <string name="restore_card_title">Відновити з резервного копіювання</string>
+    <string name="restore_card_description">Отримайте дані про кошиків із раніше створеного резервного файлу.</string>
+    <string name="backup_information_title">Резервна інформація</string>
+    <string name="last_backup_date_label">Останнє резервне копіювання:</string>
+    <string name="never_backed_up">Ніколи</string>
+    <string name="auto_backup_title">Автоматичні резервні копії</string>
+    <string name="auto_backup_summary">Автоматично створюйте резервні копії даних кошика щодня.</string>
+    <string name="backup_successful_detail">Резервне копіювання створено успішно!
+Розташування: %s</string>
+    <string name="backup_cancelled_by_user">Резервне копіювання скасовано користувачем.</string>
+    <string name="backup_failed">Не вдалося резервне копіювання: %s</string>
+    <string name="unknown_error">Невідома помилка</string>
+    <string name="unknown_location">Невідоме місце розташування</string>
+    <string name="restore_successful_detail">Дані успішно відновлюються з резервного копіювання.</string>
+    <string name="restore_failed">Відновлення не вдалося: %s</string>
+    <string name="restore_cancelled_by_user">Відновити скасовано користувачем.</string>
 
     <string name="summary_preference_settings_about">Дізнайтеся більше про Cart Calculator</string>
 

--- a/app/src/main/res/values-ur-rPK/strings.xml
+++ b/app/src/main/res/values-ur-rPK/strings.xml
@@ -102,6 +102,31 @@
     <string name="save">محفوظ کریں</string>
     <string name="open_carts_after_creation">بنانے کے بعد کارٹس کھولیں</string>
     <string name="summary_preference_settings_open_carts_after_creation">بنانے کے فوراً بعد کارٹ خود بخود کھولیں۔</string>
+    <string name="backup_carts_title">بیک اپ اور کارٹ ڈیٹا کو بحال کریں</string>
+    <string name="backup_now">اب بیک اپ</string>
+    <string name="restore_from_backup">بیک اپ سے بحال کریں</string>
+    <string name="backup_successful">بیک اپ کا عمل شروع ہوا!</string>
+    <string name="restore_successful">بحالی عمل شروع کیا گیا!</string>
+    <string name="preference_title_cart_backup">بیک اپ اور بحالی</string>
+    <string name="preference_summary_cart_backup">اپنے کارٹ بیک اپ کا نظم کریں</string>
+    <string name="backup_now_card_title">ایک نیا بیک اپ بنائیں</string>
+    <string name="backup_now_card_description">مقامی اسٹوریج یا بادل کا بیک اپ بنا کر اپنے شاپنگ کارٹ ڈیٹا کو محفوظ کریں۔</string>
+    <string name="restore_card_title">بیک اپ سے بحال کریں</string>
+    <string name="restore_card_description">پہلے سے تیار کردہ بیک اپ فائل سے اپنے شاپنگ کارٹ ڈیٹا کو بازیافت کریں۔</string>
+    <string name="backup_information_title">بیک اپ کی معلومات</string>
+    <string name="last_backup_date_label">آخری بیک اپ:</string>
+    <string name="never_backed_up">کبھی نہیں</string>
+    <string name="auto_backup_title">خودکار بیک اپ</string>
+    <string name="auto_backup_summary">روزانہ اپنے کارٹ ڈیٹا کو خود بخود بیک اپ کریں۔</string>
+    <string name="backup_successful_detail">بیک اپ کامیابی کے ساتھ تخلیق کیا!
+مقام: %s</string>
+    <string name="backup_cancelled_by_user">بیک اپ صارف کے ذریعہ منسوخ.</string>
+    <string name="backup_failed">بیک اپ ناکام ہوگیا: %s</string>
+    <string name="unknown_error">نامعلوم غلطی</string>
+    <string name="unknown_location">نامعلوم مقام</string>
+    <string name="restore_successful_detail">ڈیٹا بیک اپ سے کامیابی کے ساتھ بحال ہوا۔</string>
+    <string name="restore_failed">بحالی ناکام: %s</string>
+    <string name="restore_cancelled_by_user">صارف کے ذریعہ منسوخ بحال کریں۔</string>
 
     <!-- About screen -->
     <string name="summary_preference_settings_about">کارٹ کیلکولیٹر کے بارے میں مزید جانیں</string>

--- a/app/src/main/res/values-vi-rVN/strings.xml
+++ b/app/src/main/res/values-vi-rVN/strings.xml
@@ -102,6 +102,31 @@
     <string name="save">Lưu</string>
     <string name="open_carts_after_creation">Mở giỏ hàng sau khi tạo</string>
     <string name="summary_preference_settings_open_carts_after_creation">Tự động mở giỏ hàng ngay sau khi được tạo.</string>
+    <string name="backup_carts_title">Sao lưu và khôi phục dữ liệu giỏ hàng</string>
+    <string name="backup_now">Sao lưu ngay bây giờ</string>
+    <string name="restore_from_backup">Khôi phục từ sao lưu</string>
+    <string name="backup_successful">Quá trình sao lưu bắt đầu!</string>
+    <string name="restore_successful">Khôi phục quá trình bắt đầu!</string>
+    <string name="preference_title_cart_backup">Sao lưu &amp; Khôi phục</string>
+    <string name="preference_summary_cart_backup">Quản lý sao lưu giỏ hàng của bạn</string>
+    <string name="backup_now_card_title">Tạo một bản sao lưu mới</string>
+    <string name="backup_now_card_description">Bảo mật dữ liệu giỏ hàng của bạn bằng cách tạo bản sao lưu vào bộ nhớ cục bộ hoặc đám mây.</string>
+    <string name="restore_card_title">Khôi phục từ sao lưu</string>
+    <string name="restore_card_description">Lấy dữ liệu giỏ hàng của bạn từ một tệp sao lưu được tạo trước đó.</string>
+    <string name="backup_information_title">Thông tin sao lưu</string>
+    <string name="last_backup_date_label">Bản sao lưu cuối cùng:</string>
+    <string name="never_backed_up">Không bao giờ</string>
+    <string name="auto_backup_title">Sao lưu tự động</string>
+    <string name="auto_backup_summary">Tự động sao lưu dữ liệu giỏ hàng của bạn hàng ngày.</string>
+    <string name="backup_successful_detail">Sao lưu đã tạo ra thành công!
+Vị trí: %s</string>
+    <string name="backup_cancelled_by_user">Sao lưu bị hủy bởi người dùng.</string>
+    <string name="backup_failed">Sao lưu không thành công: %s</string>
+    <string name="unknown_error">Lỗi không xác định</string>
+    <string name="unknown_location">Vị trí không xác định</string>
+    <string name="restore_successful_detail">Dữ liệu được khôi phục thành công từ bản sao lưu.</string>
+    <string name="restore_failed">Khôi phục thất bại: %s</string>
+    <string name="restore_cancelled_by_user">Khôi phục bị hủy bởi người dùng.</string>
 
     <!-- About screen -->
     <string name="summary_preference_settings_about">Tìm hiểu thêm về Cart Calculator</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -99,6 +99,31 @@
     <string name="save">儲存</string>
     <string name="open_carts_after_creation">建立後開啟購物車</string>
     <string name="summary_preference_settings_open_carts_after_creation">建立購物車後立即自動開啟。</string>
+    <string name="backup_carts_title">備份和還原購物車數據</string>
+    <string name="backup_now">現在備份</string>
+    <string name="restore_from_backup">從備份還原</string>
+    <string name="backup_successful">備份過程開始了！</string>
+    <string name="restore_successful">恢復過程啟動！</string>
+    <string name="preference_title_cart_backup">備份和還原</string>
+    <string name="preference_summary_cart_backup">管理您的購物車備用</string>
+    <string name="backup_now_card_title">創建一個新的備份</string>
+    <string name="backup_now_card_description">通過創建本地存儲或云的備份來保護購物車數據。</string>
+    <string name="restore_card_title">從備份還原</string>
+    <string name="restore_card_description">從先前創建的備份文件中檢索購物車數據。</string>
+    <string name="backup_information_title">備份信息</string>
+    <string name="last_backup_date_label">最後備份：</string>
+    <string name="never_backed_up">絕不</string>
+    <string name="auto_backup_title">自動備份</string>
+    <string name="auto_backup_summary">每天自動備份購物車數據。</string>
+    <string name="backup_successful_detail">備份成功創建了！
+地點： %s</string>
+    <string name="backup_cancelled_by_user">用戶取消備份。</string>
+    <string name="backup_failed">備份失敗： %s</string>
+    <string name="unknown_error">未知錯誤</string>
+    <string name="unknown_location">未知位置</string>
+    <string name="restore_successful_detail">數據從備份成功恢復。</string>
+    <string name="restore_failed">還原失敗： %s</string>
+    <string name="restore_cancelled_by_user">用戶取消還原。</string>
 
     <string name="summary_preference_settings_about">瞭解更多關於購物車計算機</string>
 


### PR DESCRIPTION
## Summary
- add translations for backup/restore strings in every language

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851454c3968832d8ddd042446a38cd2