### PR TITLE
Fix buildUnifiedCartList resource strings

### DIFF
--- a/app/src/main/java/com/d4rk/cartcalculator/app/cart/details/ui/utils/helpers/CartListBuilderHelper.kt
+++ b/app/src/main/java/com/d4rk/cartcalculator/app/cart/details/ui/utils/helpers/CartListBuilderHelper.kt
@@ -1,23 +1,38 @@
 package com.d4rk.cartcalculator.app.cart.details.ui.utils.helpers
 
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.res.stringResource
+import com.d4rk.cartcalculator.app.R
 import com.d4rk.cartcalculator.app.cart.details.domain.model.ui.CartListItem
 import com.d4rk.cartcalculator.app.cart.list.ui.utils.constants.ui.UiConstants
 import com.d4rk.cartcalculator.core.data.database.table.ShoppingCartItemsTable
 
 object CartListBuilderHelper {
 
+    @Composable
     fun buildUnifiedCartList(items : List<ShoppingCartItemsTable> , adsEnabled : Boolean) : List<CartListItem> {
         val checked : List<ShoppingCartItemsTable> = items.filter { it.isChecked }
         val unchecked : List<ShoppingCartItemsTable> = items.filter { ! it.isChecked }
 
+        val inCartLabel = stringResource(id = R.string.in_cart)
+        val itemsToPickUpLabel = stringResource(id = R.string.items_to_pick_up)
+
         return buildList {
             if (checked.isNotEmpty()) {
-                add(element = CartListItem.Header(label = "In Cart (${checked.size})"))
+                add(
+                    element = CartListItem.Header(
+                        label = "$inCartLabel (${checked.size})"
+                    )
+                )
                 addAll(elements = injectAds(items = checked , adsEnabled = adsEnabled))
             }
 
             if (unchecked.isNotEmpty()) {
-                add(element = CartListItem.Header(label = "Items to Pick Up (${unchecked.size})"))
+                add(
+                    element = CartListItem.Header(
+                        label = "$itemsToPickUpLabel (${unchecked.size})"
+                    )
+                )
                 addAll(elements = injectAds(items = unchecked , adsEnabled = adsEnabled))
             }
         }


### PR DESCRIPTION
## Summary
- use `stringResource` for building list headers

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6878034ab660832dad3ae0b4e2f66530